### PR TITLE
PhysGun needs to inherit IFrameUpdate for effects

### DIFF
--- a/code/tools/PhysGun.Effects.cs
+++ b/code/tools/PhysGun.Effects.cs
@@ -1,7 +1,7 @@
 ﻿using Sandbox;
 using System.Linq;
 
-public partial class PhysGun
+public partial class PhysGun : IFrameUpdate
 {
 	Particles Beam;
 	Particles EndNoHit;


### PR DESCRIPTION
Physgun beam effects weren't working properly, OnFrame was never getting called, solved by inheriting IFrameUpdate.