### PR TITLE
Call base.ClientJoined to notify about new player

### DIFF
--- a/code/Game.cs
+++ b/code/Game.cs
@@ -20,6 +20,7 @@ partial class SandboxGame : Game
 
 	public override void ClientJoined( Client cl )
 	{
+		base.ClientJoined( cl );
 		var player = new SandboxPlayer();
 		player.Respawn();
 


### PR DESCRIPTION
This is a very small change and not as important but it should still be usefull to call `base.ClientJoined( cl );` when a player joins so everyone knows that a player has joined.

But in case there is a reason why it is not called i dont mind if it doesn't get merged ^^