### PR TITLE
Disable noclip on player death

### DIFF
--- a/code/Player.cs
+++ b/code/Player.cs
@@ -29,6 +29,11 @@ partial class SandboxPlayer : Player
 		Animator = new StandardPlayerAnimator();
 		Camera = new FirstPersonCamera();
 
+		if ( DevController is NoclipController )
+		{
+			DevController = null;
+		}
+
 		EnableAllCollisions = true;
 		EnableDrawing = true;
 		EnableHideInFirstPerson = true;


### PR DESCRIPTION
When a player dies whilst in noclip, they respawn with noclip. This change disables noclip on respawn

Before:
https://user-images.githubusercontent.com/25727384/119311832-e5c59b00-bcb4-11eb-8bba-9b65ef6fbe63.mp4

After:
https://user-images.githubusercontent.com/25727384/119311882-f7a73e00-bcb4-11eb-94b1-87c5ab01a885.mp4

