### PR TITLE
Keep last camera on death

### DIFF
--- a/code/Player.cs
+++ b/code/Player.cs
@@ -16,9 +16,16 @@ partial class SandboxPlayer : Player
 	[Net]
 	public PawnAnimator VehicleAnimator { get; set; }
 
+	public ICamera LastCamera { get; set; }
+
 	public SandboxPlayer()
 	{
 		Inventory = new Inventory( this );
+	}
+	public override void Spawn()
+	{
+		LastCamera = new FirstPersonCamera();
+		base.Spawn();
 	}
 
 	public override void Respawn()
@@ -27,7 +34,7 @@ partial class SandboxPlayer : Player
 
 		Controller = new WalkController();
 		Animator = new StandardPlayerAnimator();
-		Camera = new FirstPersonCamera();
+		Camera = LastCamera;
 
 		EnableAllCollisions = true;
 		EnableDrawing = true;
@@ -49,6 +56,7 @@ partial class SandboxPlayer : Player
 		base.OnKilled();
 
 		BecomeRagdollOnClient( Velocity, lastDamage.Flags, lastDamage.Position, lastDamage.Force, GetHitboxBone( lastDamage.HitboxIndex ) );
+		LastCamera = Camera;
 		Camera = new SpectateRagdollCamera();
 		Controller = null;
 


### PR DESCRIPTION
On death, the camera would switch back to first-person regardless if you were in third-person or not.
This introduces a "LastCamera" which keeps track of the last used camera on death and it's set on respawn.

Before: 
https://user-images.githubusercontent.com/25727384/119311569-941d1080-bcb4-11eb-91d1-9a2de8378f17.mp4

After: 
https://user-images.githubusercontent.com/25727384/119311405-633cdb80-bcb4-11eb-9c77-e20a3635d9ed.mp4