### PR TITLE
Add IStopUsing, counterpart to IUse

### DIFF
--- a/code/IStopUsing.cs
+++ b/code/IStopUsing.cs
@@ -1,0 +1,8 @@
+namespace Sandbox
+{
+	// If an entity implements this it'll receive an OnStopUsing when a player stops pushing the USE button
+	public interface IStopUsing
+	{
+		void OnStopUsing( Entity user );
+	}
+}

--- a/code/Player.Use.cs
+++ b/code/Player.Use.cs
@@ -32,4 +32,12 @@ partial class SandboxPlayer
 
 		base.UseFail();
 	}
+
+	protected override void StopUsing()
+	{
+		if ( Using is IStopUsing use ) {
+			use.OnStopUsing( this );
+		}
+		base.StopUsing();
+	}
 }


### PR DESCRIPTION
This allows triggering logic in an Entity when the user stops holding use.

eg. for resetting a button's position back to the unpressed state, or for stopping the sound triggered by the initial Use