### PR TITLE
Physgun Beam Line Light

### DIFF
--- a/Assets/weapons/Physgun/physgun.prefab
+++ b/Assets/weapons/Physgun/physgun.prefab
@@ -212,6 +212,18 @@
               ]
             },
             "Wireframe": false
+          },
+          {
+            "__type": "Sandbox.LineRendererLight",
+            "__guid": "99fc90b6-b23a-4af9-8c26-b0f29eb1eb55",
+            "__enabled": true,
+            "Brightness": 0.1,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null
           }
         ],
         "Children": []

--- a/Code/Effects/LineRendererLight.cs
+++ b/Code/Effects/LineRendererLight.cs
@@ -1,0 +1,71 @@
+namespace Sandbox;
+
+[Title("Line Renderer Light")]
+public class LineRendererLight : Component, Component.ExecuteInEditor
+{
+    LineRenderer Renderer;
+    SceneLight so;
+
+    [Property] public float Brightness { get; set; } = 1.0f;
+    
+    public LineRendererLight()
+    {
+    }
+
+    protected override void OnEnabled()
+    {
+        Renderer = Components.GetInAncestorsOrSelf<LineRenderer>();
+
+        if ( Renderer is null )
+        {
+            Log.Warning( $"No line renderer component found for {this}" );
+            return;
+        }
+
+        // Clean up any existing light
+        if ( so.IsValid() )
+            so.Delete();
+
+        so = new SceneLight( Renderer.Scene.SceneWorld, Vector3.Zero, 100, Color.Red );
+    }
+
+	protected override void OnDisabled()
+	{
+		if ( !so.IsValid() ) return;
+		so.Delete();
+	}
+
+    protected override void OnUpdate()
+    {
+        if (!so.IsValid() || Renderer == null) return;
+        
+        // Skip update if renderer has no points
+        bool useVectorPoints = Renderer.UseVectorPoints;
+        if ((useVectorPoints && (Renderer.VectorPoints == null || Renderer.VectorPoints.Count == 0)) ||
+            (!useVectorPoints && (Renderer.Points == null || Renderer.Points.Count == 0)))
+            return;
+        
+        Vector3 p1, p2;
+
+        if (useVectorPoints)
+        {
+            p1 = Renderer.VectorPoints.First();
+            p2 = Renderer.VectorPoints.Last();
+        }
+        else
+        {
+            p1 = Renderer.Points.First().WorldPosition;
+            p2 = Renderer.Points.Last().WorldPosition;
+        }
+
+        float distance = p1.Distance(p2);
+        
+        
+        so.Position = ( p1 + p2 ) / 2.0f;
+        so.Radius = 256 + p1.Distance( p2 );
+		so.LightColor = Renderer.Color.Evaluate( 0.5f ) * Brightness;
+		so.ShapeSize = new Vector2( 2.0f, p1.Distance( p2 ) );
+		so.Rotation = Rotation.LookAt( p2 - p1 );
+		so.Shape = SceneLight.LightShape.Capsule;
+    }
+}

--- a/Code/Weapons/PhysGun/Physgun.Effects.cs
+++ b/Code/Weapons/PhysGun/Physgun.Effects.cs
@@ -21,7 +21,7 @@ public partial class Physgun : BaseCarryable
 			BeamHighlight.Color = Color.Lerp( Color.Cyan, Color.White, Noise.Fbm( 3, Time.Now * 40.0f ) * 0.5f ) * 200.0f;
 		}
 
-		bool justEnabled = !BeamRenderer.Enabled;
+		bool justEnabled = !BeamRenderer.GameObject.Enabled;
 
 		if ( BeamRenderer.VectorPoints.Count != 4 )
 			BeamRenderer.VectorPoints = new List<Vector3>( [0, 0, 0, 0] );
@@ -43,7 +43,7 @@ public partial class Physgun : BaseCarryable
 
 		if ( justEnabled )
 		{
-			BeamRenderer.Enabled = true;
+			BeamRenderer.GameObject.Enabled = true;
 			BeamRenderer.VectorPoints[1] = targetMiddle;
 			middleSpring = new Vector3.SpringDamped( targetMiddle, targetMiddle, 0.2f, 4, 0.2f );
 		}
@@ -69,7 +69,7 @@ public partial class Physgun : BaseCarryable
 
 		if ( !BeamRenderer.IsValid() ) return;
 
-		BeamRenderer.Enabled = false;
+		BeamRenderer.GameObject.Enabled = false;
 	}
 
 }


### PR DESCRIPTION
Adds a nice physically-accurate faint beam to the physgun taking from Line Renderer Light from SceneStaging

Goes on a straight line instead of curving but looks convincing enough

This is a PR since we are taking things from scene staging and might be worth to discussion if to wait until it's on engine, but could keep a preliminary API version for it to sandbox, 

Area lights for engine are waiting for shadows2, for line lights they are likely not to have shadows anyway

![](https://files.facepunch.com/sampavlovic/1b0111b1/sbox-dev_p9I1HKel34.png)
![](https://files.facepunch.com/sampavlovic/1b0111b1/sbox-dev_EbIcfqMz3Q.jpg)
![](https://files.facepunch.com/sampavlovic/1b0111b1/sbox-dev_PnhWNLt7EG.jpg)