### PR TITLE
Spawn dupe when packages loaded

### DIFF
--- a/Code/Weapons/ToolGun/Modes/Duplicator/DuplicationData.cs
+++ b/Code/Weapons/ToolGun/Modes/Duplicator/DuplicationData.cs
@@ -22,7 +22,7 @@ public class DuplicationData
 	/// <summary>
 	/// Describes where to draw a model for the preview
 	/// </summary>
-	public record struct PreviewModel( Model Model, Transform Transform, Transform[] Bones );
+	public record struct PreviewModel( Model Model, Transform Transform, Transform[] Bones, BBox Bounds );
 
 	/// <summary>
 	/// A list of preview models to help visualze where the duplication will be placed
@@ -71,7 +71,7 @@ public class DuplicationData
 				}
 
 				var modelTx = center.ToLocal( model.WorldTransform );
-				dupe.PreviewModels.Add( new DuplicationData.PreviewModel( model.Model, modelTx, bones ) );
+				dupe.PreviewModels.Add( new DuplicationData.PreviewModel( model.Model, modelTx, bones, model.Model.Bounds ) );
 			}
 		}
 


### PR DESCRIPTION
related to https://github.com/Facepunch/sandbox/issues/49

Dupes can only be spawned once all packages are loaded, error models are rendered as bounds. Collision are hotloaded now but I don't think we want to be spawning dupes and seeing error models.

This would only apply to newly uploaded dupe data so I want to check if we actually want to do this. I couldn't find a nice way to match a model to a package to be able to get the preview bounds from that instead.