### PR TITLE
Save System

### DIFF
--- a/Code/GameLoop/GameManager.cs
+++ b/Code/GameLoop/GameManager.cs
@@ -36,6 +36,10 @@ public sealed partial class GameManager : GameObjectSystem<GameManager>, Compone
 
 	private PlayerData CreatePlayerInfo( Connection channel )
 	{
+		var existingPlayerInfo = PlayerData.For( channel );
+		if ( existingPlayerInfo.IsValid() )
+			return existingPlayerInfo;
+
 		var go = new GameObject( true, $"PlayerInfo - {channel.DisplayName}" );
 		var data = go.AddComponent<PlayerData>();
 		data.SteamId = (long)channel.SteamId;

--- a/Code/Player/PlayerData.cs
+++ b/Code/Player/PlayerData.cs
@@ -1,7 +1,7 @@
 /// <summary>
 /// Holds persistent player information like deaths, kills
 /// </summary>
-public sealed partial class PlayerData : Component
+public sealed partial class PlayerData : Component, ISaveEvents
 {
 	/// <summary>
 	/// Unique Id per each player and bot, equal to owning Player connection Id if it's a real player.
@@ -67,6 +67,16 @@ public sealed partial class PlayerData : Component
 		using ( Rpc.FilterInclude( Connection ) )
 		{
 			RpcAddStat( identifier, amount );
+		}
+	}
+
+	void ISaveEvents.OnAfterLoad()
+	{
+		var connection = Connection;
+		if ( connection == null )
+		{
+			// Get new PlayerId from SteamId if this is a new session
+			PlayerId = Connection.All.FirstOrDefault( x => x.SteamId == SteamId )?.Id ?? Guid.Empty;
 		}
 	}
 }

--- a/Code/Player/PlayerData.cs
+++ b/Code/Player/PlayerData.cs
@@ -70,7 +70,7 @@ public sealed partial class PlayerData : Component, ISaveEvents
 		}
 	}
 
-	void ISaveEvents.OnAfterLoad()
+	void ISaveEvents.AfterLoad( string filename )
 	{
 		var connection = Connection;
 		if ( connection == null )

--- a/Code/Save/ISaveEvents.cs
+++ b/Code/Save/ISaveEvents.cs
@@ -1,0 +1,31 @@
+﻿namespace Sandbox;
+
+/// <summary>
+/// Allows listening to events related to the <see cref="SaveSystem"/>.
+/// Implement this on a <see cref="Component"/> to receive callbacks before and after saves and loads.
+/// </summary>
+public interface ISaveEvents : ISceneEvent<ISaveEvents>
+{
+	/// <summary>
+	/// Called before the scene state is captured for saving.
+	/// Use this to prepare any transient state that needs to be persisted.
+	/// </summary>
+	void BeforeSave( string filename ) { }
+
+	/// <summary>
+	/// Called after the save file has been written to disk.
+	/// </summary>
+	void AfterSave( string filename ) { }
+
+	/// <summary>
+	/// Called before a save file is loaded — the current scene is still active.
+	/// Use this to clean up any state that won't survive the scene reload.
+	/// </summary>
+	void BeforeLoad( string filename ) { }
+
+	/// <summary>
+	/// Called after a save file has been loaded and the scene is fully restored.
+	/// Use this to re-initialize any runtime state from the loaded data.
+	/// </summary>
+	void AfterLoad( string filename ) { }
+}

--- a/Code/Save/SaveSystem.cs
+++ b/Code/Save/SaveSystem.cs
@@ -181,6 +181,11 @@ public sealed class SaveSystem : GameObjectSystem<SaveSystem>, ISceneLoadingEven
 	/// <returns>True if the load was successful.</returns>
 	public async Task<bool> Load( string path )
 	{
+		//
+		// Host only
+		//
+		if ( !Networking.IsHost ) return false;
+
 		if ( string.IsNullOrWhiteSpace( path ) )
 		{
 			Log.Warning( "SaveSystem: Cannot load — path is null or empty." );

--- a/Code/Save/SaveSystem.cs
+++ b/Code/Save/SaveSystem.cs
@@ -1,0 +1,819 @@
+﻿using System.IO;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Sandbox;
+
+/// <summary>
+/// A saving/loading system that captures the differences between the current scene state and the original scene.
+/// </summary>
+public sealed class SaveSystem : GameObjectSystem<SaveSystem>, ISceneLoadingEvents
+{
+	private const int CurrentSaveVersion = 1;
+	private Dictionary<string, string> _metadata = new();
+	private readonly List<LoadedSceneEntry> _loadedScenes = new();
+	private bool _suppressSystemScene;
+
+	/// <summary>
+	/// The path of the save file that was most recently loaded, if any.
+	/// </summary>
+	public string LoadedSavePath { get; private set; }
+
+	/// <summary>
+	/// Whether a save file is currently loaded.
+	/// </summary>
+	public bool HasLoadedSave => LoadedSavePath is not null;
+
+	public SaveSystem( Scene scene ) : base( scene )
+	{
+	}
+
+	/// <summary>
+	/// Set metadata on the current session's save.
+	/// This will be written on the next <see cref="Save"/> call.
+	/// </summary>
+	public void SetMetadata( string key, string value )
+	{
+		if ( string.IsNullOrWhiteSpace( key ) )
+			throw new ArgumentException( "Metadata key cannot be null or empty.", nameof( key ) );
+
+		_metadata[key] = value;
+	}
+
+	/// <summary>
+	/// Get a metadata value from the current session, falling back to a default value.
+	/// </summary>
+	public string GetMetadata( string key, string defaultValue = null )
+	{
+		if ( key is null ) return defaultValue;
+
+		return _metadata.TryGetValue( key, out var value ) ? value : defaultValue;
+	}
+
+	/// <summary>
+	/// Get a copy of all metadata for the current session.
+	/// </summary>
+	public IReadOnlyDictionary<string, string> GetAllMetadata()
+	{
+		return new Dictionary<string, string>( _metadata );
+	}
+
+	/// <summary>
+	/// Read metadata from a save file on disk without loading the full save.
+	/// Returns null if the file doesn't exist or is invalid.
+	/// </summary>
+	public static IReadOnlyDictionary<string, string> GetFileMetadata( string path )
+	{
+		if ( string.IsNullOrWhiteSpace( path ) )
+			return null;
+
+		if ( !FileSystem.Data.FileExists( path ) )
+			return null;
+
+		try
+		{
+			var text = FileSystem.Data.ReadAllText( path );
+			using var doc = JsonDocument.Parse( text );
+
+			if ( doc.RootElement.TryGetProperty( "Metadata", out var metaElement ) )
+			{
+				return JsonSerializer.Deserialize<Dictionary<string, string>>( metaElement.GetRawText() );
+			}
+
+			return new Dictionary<string, string>();
+		}
+		catch ( Exception e )
+		{
+			Log.Warning( $"SaveSystem: Failed to read metadata from '{path}': {e.Message}" );
+			return null;
+		}
+	}
+
+	/// <summary>
+	/// Save the game's state to a file, capturing the differences between the current scene to the original scene file(s).
+	/// This means any changes made to the those original scenes are preserved when loading an older save.
+	/// </summary>
+	/// <returns>True if the save was successful.</returns>
+	public bool Save( string path )
+	{
+		if ( string.IsNullOrWhiteSpace( path ) )
+		{
+			Log.Warning( "SaveSystem: Cannot save — path is null or empty." );
+			return false;
+		}
+
+		if ( !Scene.IsValid() )
+		{
+			Log.Warning( "SaveSystem: Cannot save — no valid scene." );
+			return false;
+		}
+
+		if ( _loadedScenes.Count == 0 )
+		{
+			Log.Warning( "SaveSystem: Cannot save — no tracked scene sources. The scene must be loaded from a SceneFile." );
+			return false;
+		}
+
+		Scene.RunEvent<ISaveEvents>( x => x.BeforeSave( path ) );
+
+		var baseline = BuildCompositeBaseline();
+		if ( baseline is null )
+		{
+			Log.Warning( "SaveSystem: Failed to build baseline from loaded scene sources." );
+			return false;
+		}
+
+		var current = BuildCurrentSceneJson( Scene );
+		if ( current is null )
+		{
+			Log.Warning( "SaveSystem: Failed to serialize current scene state." );
+			return false;
+		}
+
+		// Calculate the diff between baseline and current state
+		var patch = Json.CalculateDifferences( baseline, current, GameObject.DiffObjectDefinitions );
+		var sceneSources = new JsonArray();
+		foreach ( var entry in _loadedScenes )
+		{
+			sceneSources.Add( JsonValue.Create( entry.ResourcePath ) );
+		}
+
+		var primarySceneFile = GetPrimarySceneFile();
+		var networkOwnership = CollectNetworkOwnership( Scene );
+		var syncState = CollectSyncState( Scene );
+		var requiredPackages = CollectRequiredPackages( _loadedScenes, current );
+		var saveData = new JsonObject
+		{
+			["Version"] = CurrentSaveVersion,
+			["SceneSources"] = sceneSources,
+			["SceneProperties"] = primarySceneFile is not null ? SerializeScenePropertyDiffs( Scene, primarySceneFile ) : null,
+			["Metadata"] = JsonSerializer.SerializeToNode( _metadata ),
+			["Patch"] = Json.ToNode( patch ),
+			["NetworkOwnership"] = networkOwnership,
+			["SyncState"] = syncState,
+			["RequiredPackages"] = requiredPackages,
+		};
+
+		try
+		{
+			// Make sure any parent directories exist first
+			var dir = Path.GetDirectoryName( path );
+			if ( !string.IsNullOrEmpty( dir ) )
+				FileSystem.Data.CreateDirectory( dir );
+
+			FileSystem.Data.WriteAllText( path, saveData.ToJsonString() );
+			LoadedSavePath = path;
+		}
+		catch ( Exception e )
+		{
+			Log.Warning( $"SaveSystem: Failed to write save file '{path}': {e.Message}" );
+			return false;
+		}
+
+		Scene.RunEvent<ISaveEvents>( x => x.AfterSave( path ) );
+		return true;
+	}
+
+	/// <summary>
+	/// Load a previously saved game state from a file, applying the differences to the original scene file(s) to reconstruct the saved scene.
+	/// </summary>
+	/// <returns>True if the load was successful.</returns>
+	public async Task<bool> Load( string path )
+	{
+		if ( string.IsNullOrWhiteSpace( path ) )
+		{
+			Log.Warning( "SaveSystem: Cannot load — path is null or empty." );
+			return false;
+		}
+
+		if ( !Scene.IsValid() )
+		{
+			Log.Warning( "SaveSystem: Cannot load — no valid scene." );
+			return false;
+		}
+
+		if ( !FileSystem.Data.FileExists( path ) )
+		{
+			Log.Warning( $"SaveSystem: Save file '{path}' does not exist." );
+			return false;
+		}
+
+		JsonObject saveRoot;
+
+		try
+		{
+			var text = FileSystem.Data.ReadAllText( path );
+			saveRoot = JsonNode.Parse( text )?.AsObject();
+		}
+		catch ( Exception e )
+		{
+			Log.Warning( $"SaveSystem: Failed to read save file '{path}': {e.Message}" );
+			return false;
+		}
+
+		if ( saveRoot is null )
+		{
+			Log.Warning( $"SaveSystem: Save file '{path}' is empty or invalid." );
+			return false;
+		}
+
+		// Validate that the save format version is compatible
+		var saveVersion = saveRoot["Version"]?.GetValue<int>() ?? 0;
+		if ( saveVersion > CurrentSaveVersion )
+		{
+			Log.Warning( $"SaveSystem: Save file '{path}' uses version {saveVersion}, but this build only supports up to version {CurrentSaveVersion}. The save may have been created with a newer version of the game." );
+			return false;
+		}
+
+		var sceneSources = new List<string>();
+		if ( saveRoot["SceneSources"] is JsonArray sourcesArray )
+		{
+			foreach ( var source in sourcesArray )
+			{
+				var val = source?.GetValue<string>();
+				if ( !string.IsNullOrEmpty( val ) )
+					sceneSources.Add( val );
+			}
+		}
+
+		if ( sceneSources.Count == 0 )
+		{
+			Log.Warning( $"SaveSystem: Save file '{path}' has no scene sources." );
+			return false;
+		}
+
+		// Resolve all scene files from disk, the first being the primary scene
+		var sceneFiles = new List<SceneFile>();
+		foreach ( var source in sceneSources )
+		{
+			var sf = ResourceLibrary.Get<SceneFile>( source );
+			if ( sf is null )
+			{
+				Log.Warning( $"SaveSystem: Scene source '{source}' not found. Skipping." );
+				continue;
+			}
+			sceneFiles.Add( sf );
+		}
+
+		if ( sceneFiles.Count == 0 )
+		{
+			Log.Warning( $"SaveSystem: None of the scene sources from save '{path}' could be found." );
+			return false;
+		}
+
+		// Mount any cloud packages the save references before loading the scene
+		if ( saveRoot["RequiredPackages"] is JsonArray pkgArray )
+		{
+			await MountRequiredPackages( pkgArray );
+		}
+
+		Scene.RunEvent<ISaveEvents>( x => x.BeforeLoad( path ) );
+
+		Json.Patch savedPatch = null;
+		if ( saveRoot["Patch"] is JsonObject patchNode )
+		{
+			savedPatch = Json.FromNode<Json.Patch>( patchNode );
+		}
+
+		savedPatch ??= new Json.Patch();
+
+		var baseline = BuildCompositeBaselineFromFiles( sceneFiles, sceneFiles[0].Id );
+		if ( baseline is null )
+		{
+			Log.Warning( "SaveSystem: Failed to build baseline from scene sources." );
+			return false;
+		}
+
+		// Create a new SceneFile by applying the saved patch to the baseline, then load that
+		var patched = Json.ApplyPatch( baseline, savedPatch, GameObject.DiffObjectDefinitions );
+		var primarySceneFile = sceneFiles[0];
+		var savedSceneProperties = saveRoot["SceneProperties"];
+		var patchedSceneFile = BuildPatchedSceneFile( primarySceneFile, patched, savedSceneProperties );
+		_suppressSystemScene = true; // Make sure we don't load two system scenes.....
+
+		var options = new SceneLoadOptions();
+		options.SetScene( patchedSceneFile );
+
+		if ( !Scene.Load( options ) )
+		{
+			_suppressSystemScene = false;
+			Log.Warning( $"SaveSystem: Failed to load patched scene from save '{path}'." );
+			return false;
+		}
+
+		// Make sure we keep track of the original scene sources in case we re-save from this loaded state
+		_loadedScenes.Clear();
+		foreach ( var sf in sceneFiles )
+		{
+			if ( string.IsNullOrEmpty( sf.ResourcePath ) ) continue;
+			_loadedScenes.Add( new LoadedSceneEntry
+			{
+				ResourcePath = sf.ResourcePath,
+				SceneFileId = sf.Id
+			} );
+		}
+
+		// Restore metadata
+		_metadata = saveRoot["Metadata"] is JsonObject metaNode
+			? JsonSerializer.Deserialize<Dictionary<string, string>>( metaNode ) ?? new Dictionary<string, string>()
+			: new Dictionary<string, string>();
+		LoadedSavePath = path;
+
+		// Restore [Sync] property values before network ownership so everything is populated BEFORE any ownership-change callbacks fire.
+		if ( saveRoot["SyncState"] is JsonObject syncNode )
+		{
+			RestoreSyncState( Scene, syncNode );
+		}
+
+		if ( saveRoot["NetworkOwnership"] is JsonObject ownershipNode )
+		{
+			RestoreNetworkOwnership( Scene, ownershipNode );
+		}
+
+		Scene.RunEvent<ISaveEvents>( x => x.AfterLoad( path ) );
+		return true;
+	}
+
+	// Before we load any scene, we keep track of the source scene file so we can diff against it later when saving
+	void ISceneLoadingEvents.BeforeLoad( Scene scene, SceneLoadOptions options )
+	{
+		var sceneFile = options.GetSceneFile();
+		if ( sceneFile is null ) return;
+
+		if ( !options.IsAdditive )
+		{
+			_loadedScenes.Clear();
+			_metadata.Clear();
+			LoadedSavePath = null;
+		}
+
+		var resourcePath = sceneFile.ResourcePath;
+
+		// The scene file might be in-memory (e.g. editor Play creates one via
+		// CreateSceneFile). Try to resolve the original on-disk scene file by
+		// checking Scene.Source, then by matching the scene file's Id against
+		// all loaded SceneFile resources.
+		if ( string.IsNullOrEmpty( resourcePath ) && scene.Source is SceneFile sourceFile )
+		{
+			resourcePath = sourceFile.ResourcePath;
+		}
+
+		if ( string.IsNullOrEmpty( resourcePath ) && sceneFile.Id != Guid.Empty )
+		{
+			var match = ResourceLibrary.GetAll<SceneFile>()
+				.FirstOrDefault( x => x.Id == sceneFile.Id && !string.IsNullOrEmpty( x.ResourcePath ) );
+
+			if ( match is not null )
+				resourcePath = match.ResourcePath;
+		}
+
+		if ( string.IsNullOrEmpty( resourcePath ) )
+			return;
+		if ( _loadedScenes.Any( e => e.ResourcePath == resourcePath ) )
+			return;
+
+		_loadedScenes.Add( new LoadedSceneEntry
+		{
+			ResourcePath = resourcePath,
+			SceneFileId = sceneFile.Id
+		} );
+	}
+
+	// When loading a scene, we hook into it and make sure WantsSystemScene is false when we need to prevent duplicates
+	Task ISceneLoadingEvents.OnLoad( Scene scene, SceneLoadOptions options, LoadingContext context )
+	{
+		if ( _suppressSystemScene )
+		{
+			scene.WantsSystemScene = false;
+			_suppressSystemScene = false;
+		}
+
+		return Task.CompletedTask;
+	}
+
+	private sealed class LoadedSceneEntry
+	{
+		public string ResourcePath { get; init; }
+		public Guid SceneFileId { get; init; }
+	}
+
+	private SceneFile GetPrimarySceneFile()
+	{
+		if ( _loadedScenes.Count == 0 ) return null;
+		return ResourceLibrary.Get<SceneFile>( _loadedScenes[0].ResourcePath );
+	}
+
+	private static JsonArray CollectRequiredPackages( List<LoadedSceneEntry> loadedScenes, JsonObject currentSceneJson )
+	{
+		var packages = new HashSet<string>( StringComparer.OrdinalIgnoreCase );
+
+		foreach ( var entry in loadedScenes )
+		{
+			var sf = ResourceLibrary.Get<SceneFile>( entry.ResourcePath );
+			if ( sf is null ) continue;
+
+			foreach ( var pkg in sf.GetReferencedPackages() )
+			{
+				if ( !string.IsNullOrEmpty( pkg ) )
+					packages.Add( pkg );
+			}
+		}
+
+		if ( currentSceneJson is not null )
+		{
+			foreach ( var pkg in Cloud.ResolvePrimaryAssetsFromJson( currentSceneJson ) )
+			{
+				if ( !string.IsNullOrEmpty( pkg.FullIdent ) )
+					packages.Add( pkg.FullIdent );
+			}
+		}
+
+		var result = new JsonArray();
+		foreach ( var ident in packages )
+		{
+			result.Add( JsonValue.Create( ident ) );
+		}
+
+		return result;
+	}
+
+	private static async Task MountRequiredPackages( JsonArray packageArray )
+	{
+		foreach ( var node in packageArray )
+		{
+			var ident = node?.GetValue<string>();
+			if ( string.IsNullOrEmpty( ident ) ) continue;
+
+			// Skip packages that are already mounted
+			if ( Package.TryGetCached( ident, out var _ ) )
+				continue;
+
+			await Package.MountAsync( ident, false );
+		}
+	}
+
+	/// <summary>
+	/// This builds a baseline JSON from all the loaded scene files that we've tracked in BeforeLoad.
+	/// The final scene gets diffed against this.
+	/// </summary>
+	private JsonObject BuildCompositeBaseline()
+	{
+		var sceneFiles = new List<SceneFile>();
+		foreach ( var entry in _loadedScenes )
+		{
+			var sf = ResourceLibrary.Get<SceneFile>( entry.ResourcePath );
+			if ( sf is null )
+			{
+				Log.Warning( $"SaveSystem: Tracked scene '{entry.ResourcePath}' could not be found." );
+				continue;
+			}
+			sceneFiles.Add( sf );
+		}
+
+		return BuildCompositeBaselineFromFiles( sceneFiles, Scene.Id );
+	}
+
+	/// <summary>
+	/// Builds a composite baseline JSON from a list of scene files by merging
+	/// all their GameObjects into a single root node.
+	/// </summary>
+	/// <param name="sceneFiles">The scene files to merge.</param>
+	/// <param name="rootId">The GUID to use for the root node. Match the scene's root ID to make sure diffs dont get fucked.</param>
+	private static JsonObject BuildCompositeBaselineFromFiles( List<SceneFile> sceneFiles, Guid rootId )
+	{
+		if ( sceneFiles.Count == 0 ) return null;
+
+		var children = new JsonArray();
+
+		foreach ( var sceneFile in sceneFiles )
+		{
+			if ( sceneFile?.GameObjects is null ) continue;
+
+			foreach ( var go in sceneFile.GameObjects )
+			{
+				if ( go is null ) continue;
+				children.Add( go.DeepClone() );
+			}
+		}
+
+		// The root needs to look like a valid GameObject for the diff to actually work
+		var root = new JsonObject
+		{
+			["__guid"] = rootId.ToString(),
+			["Flags"] = 0,
+			["Components"] = new JsonArray(),
+			["Children"] = children,
+		};
+
+		return root;
+	}
+
+	/// <summary>
+	/// Serializes the current live scene as a JSON object in the same format as <see cref="BuildCompositeBaseline"/> so the two can be diffed.
+	/// </summary>
+	private static JsonObject BuildCurrentSceneJson( Scene scene )
+	{
+		using var sceneScope = scene.Push();
+
+		var children = new JsonArray();
+
+		foreach ( var child in scene.Children )
+		{
+			// Skip DontDestroyOnLoad objects — they persist across scene loads and probably shouldn't be part of the save diff (?)
+			if ( child.Flags.Contains( GameObjectFlags.DontDestroyOnLoad ) )
+				continue;
+
+			var jso = child.Serialize();
+			if ( jso is null ) continue;
+
+			children.Add( jso );
+		}
+
+		// Needs to look like a GameObject for diffs to work
+		var root = new JsonObject
+		{
+			["__guid"] = scene.Id.ToString(),
+			["Flags"] = 0,
+			["Components"] = new JsonArray(),
+			["Children"] = children,
+		};
+
+		return root;
+	}
+
+	/// <summary>
+	/// Get any changes made to scene-level properties (like gravity, nav mesh settings, etc)
+	/// </summary>
+	private static JsonNode SerializeScenePropertyDiffs( Scene scene, SceneFile sceneFile )
+	{
+		var currentProps = scene.SerializeProperties();
+		var baseProps = sceneFile.SceneProperties;
+
+		if ( baseProps is null )
+			return currentProps?.DeepClone();
+
+		// Only store properties that ACTUALLY differ from the baseline
+		var diffs = new JsonObject();
+		var hasChanges = false;
+
+		foreach ( var prop in currentProps )
+		{
+			if ( baseProps.TryGetPropertyValue( prop.Key, out var baseValue ) )
+			{
+				if ( !JsonNode.DeepEquals( baseValue, prop.Value ) )
+				{
+					diffs[prop.Key] = prop.Value?.DeepClone();
+					hasChanges = true;
+				}
+			}
+			else
+			{
+				// New property not in baseline
+				diffs[prop.Key] = prop.Value?.DeepClone();
+				hasChanges = true;
+			}
+		}
+
+		return hasChanges ? diffs : null;
+	}
+
+	/// <summary>
+	/// Snapshots network ownership for all owned GameObjects in the scene, storing the Connection ID and SteamID to be used as fallback
+	/// </summary>
+	private static JsonObject CollectNetworkOwnership( Scene scene )
+	{
+		var result = new JsonObject();
+
+		foreach ( var go in scene.GetAllObjects( true ) )
+		{
+			if ( !go.Network.Active ) continue;
+
+			var owner = go.Network.Owner;
+			if ( owner is null ) continue;
+
+			result[go.Id.ToString()] = new JsonObject
+			{
+				["ConnectionId"] = owner.Id.ToString(),
+				["SteamId"] = owner.SteamId.Value,
+			};
+		}
+
+		return result;
+	}
+
+	/// <summary>
+	/// Restores network ownership, first trying to match by Connection ID (same session, also works when testing with a second instance of the same SteamID)
+	/// falling back to SteamID (for when loading a save from a previous session).
+	/// </summary>
+	private static void RestoreNetworkOwnership( Scene scene, JsonObject ownershipData )
+	{
+		// SteamId -> Connection lookup for fallback matching
+		var steamIdToConnection = new Dictionary<long, Connection>();
+		foreach ( var conn in Connection.All )
+		{
+			steamIdToConnection.TryAdd( conn.SteamId.Value, conn );
+		}
+
+		foreach ( var (goGuidStr, node) in ownershipData )
+		{
+			if ( !Guid.TryParse( goGuidStr, out var goGuid ) ) continue;
+			if ( node is not JsonObject entry ) continue;
+
+			var go = scene.Directory.FindByGuid( goGuid ) as GameObject;
+			if ( go is null || !go.IsValid() ) continue;
+
+			// Try matching by connection Id first (for same session)
+			Connection target = null;
+
+			if ( entry["ConnectionId"]?.GetValue<string>() is string connIdStr && Guid.TryParse( connIdStr, out var connId ) )
+			{
+				target = Connection.Find( connId );
+			}
+
+			// Fall back to SteamId (new session)
+			if ( target is null && entry["SteamId"]?.GetValue<long>() is long steamIdValue && steamIdValue != 0 )
+			{
+				steamIdToConnection.TryGetValue( steamIdValue, out target );
+			}
+
+			if ( target is null ) continue;
+
+			// Only the host can reassign ownership, and the object must be networked
+			if ( !go.Network.Active )
+			{
+				go.NetworkSpawn( target );
+			}
+			else
+			{
+				go.Network.AssignOwnership( target );
+			}
+		}
+	}
+
+	/// <summary>
+	/// Collects all [Sync]-only property values from every component in the scene, so the networked state can be restored
+	/// </summary>
+	private static JsonObject CollectSyncState( Scene scene )
+	{
+		var result = new JsonObject();
+
+		foreach ( var go in scene.GetAllObjects( true ) )
+		{
+			if ( go.Flags.Contains( GameObjectFlags.DontDestroyOnLoad ) )
+				continue;
+
+			foreach ( var component in go.Components.GetAll() )
+			{
+				var typeDesc = TypeLibrary.GetType( component.GetType() );
+				if ( typeDesc is null ) continue;
+
+				var syncProps = typeDesc.Properties.Where( p => p.HasAttribute<SyncAttribute>() );
+				JsonObject componentData = null;
+
+				foreach ( var syncProp in syncProps )
+				{
+					// Skip properties that also have [Property] since those are already captured by the main diff
+					if ( syncProp.HasAttribute<PropertyAttribute>() )
+						continue;
+
+					try
+					{
+						var value = syncProp.GetValue( component );
+
+						// Try JSON first, then fallback to bytepack (mostly for the types that don't serialize well)
+						JsonNode node;
+						try
+						{
+							node = Json.ToNode( value, syncProp.PropertyType );
+						}
+						catch
+						{
+							var bs = ByteStream.Create( 256 );
+							try
+							{
+								Game.TypeLibrary.ToBytes( value, ref bs );
+								var base64 = Convert.ToBase64String( bs.ToArray() );
+								node = new JsonObject { ["__bytepack"] = base64 };
+							}
+							finally
+							{
+								bs.Dispose();
+							}
+						}
+
+						componentData ??= new JsonObject();
+						componentData[syncProp.Name] = node;
+					}
+					catch ( Exception e )
+					{
+						Log.Warning( $"SaveSystem: Failed to serialize [Sync] property {component.GetType().Name}.{syncProp.Name}: {e.Message}" );
+					}
+				}
+
+				if ( componentData is not null )
+				{
+					result[component.Id.ToString()] = componentData;
+				}
+			}
+		}
+
+		return result;
+	}
+
+	/// <summary>
+	/// Restore the [Sync]-only properties
+	/// </summary>
+	private static void RestoreSyncState( Scene scene, JsonObject syncData )
+	{
+		foreach ( var (compGuidStr, node) in syncData )
+		{
+			if ( !Guid.TryParse( compGuidStr, out var compGuid ) ) continue;
+			if ( node is not JsonObject propData ) continue;
+
+			var target = scene.Directory.FindComponentByGuid( compGuid );
+			if ( target is null ) continue;
+
+			var typeDesc = TypeLibrary.GetType( target.GetType() );
+			if ( typeDesc is null ) continue;
+
+			var syncProps = typeDesc.Properties.Where( p => p.HasAttribute<SyncAttribute>() );
+
+			foreach ( var syncProp in syncProps )
+			{
+				if ( syncProp.HasAttribute<PropertyAttribute>() )
+					continue;
+
+				if ( !propData.ContainsKey( syncProp.Name ) )
+					continue;
+
+				try
+				{
+					var jsonValue = propData[syncProp.Name];
+
+					object value;
+
+					// Check if this was serialized via BytePack fallback
+					if ( jsonValue is JsonObject wrapper && wrapper.ContainsKey( "__bytepack" ) )
+					{
+						var base64 = wrapper["__bytepack"]!.GetValue<string>();
+						var bytes = Convert.FromBase64String( base64 );
+						var reader = ByteStream.CreateReader( bytes );
+						try
+						{
+							value = Game.TypeLibrary.FromBytes<object>( ref reader );
+						}
+						finally
+						{
+							reader.Dispose();
+						}
+					}
+					else
+					{
+						// JSON deserialize as normal
+						value = Json.FromNode( jsonValue, syncProp.PropertyType );
+					}
+
+					syncProp.SetValue( target, value );
+				}
+				catch ( Exception e )
+				{
+					Log.Warning( $"SaveSystem: Failed to restore [Sync] property {target.GetType().Name}.{syncProp.Name}: {e.Message}" );
+				}
+			}
+		}
+	}
+
+	/// <summary>
+	/// Constructs a <see cref="SceneFile"/> from the patched JSON data so we can load it just like any other scene
+	/// </summary>
+	private static SceneFile BuildPatchedSceneFile( SceneFile original, JsonObject patchedRoot, JsonNode savedSceneProperties )
+	{
+		var patchedSceneFile = new SceneFile
+		{
+			Id = original.Id,
+		};
+
+		if ( patchedRoot["Children"] is JsonArray goArray )
+		{
+			patchedSceneFile.GameObjects = goArray
+				.Where( x => x is JsonObject )
+				.Select( x => x.DeepClone().AsObject() )
+				.ToArray();
+		}
+
+		// Start with original scene properties, then apply any saved overrides
+		var sceneProperties = original.SceneProperties?.DeepClone()?.AsObject() ?? new JsonObject();
+
+		if ( savedSceneProperties is JsonObject overrides )
+		{
+			foreach ( var prop in overrides )
+			{
+				sceneProperties[prop.Key] = prop.Value?.DeepClone();
+			}
+		}
+
+		patchedSceneFile.SceneProperties = sceneProperties;
+
+		return patchedSceneFile;
+	}
+}

--- a/Code/Save/SaveSystem.cs
+++ b/Code/Save/SaveSystem.cs
@@ -145,6 +145,7 @@ public sealed class SaveSystem : GameObjectSystem<SaveSystem>, ISceneLoadingEven
 		var saveData = new JsonObject
 		{
 			["Version"] = CurrentSaveVersion,
+			["SceneId"] = Scene.Id.ToString(),
 			["SceneSources"] = sceneSources,
 			["SceneProperties"] = primarySceneFile is not null ? SerializeScenePropertyDiffs( Scene, primarySceneFile ) : null,
 			["Metadata"] = JsonSerializer.SerializeToNode( _metadata ),
@@ -277,7 +278,12 @@ public sealed class SaveSystem : GameObjectSystem<SaveSystem>, ISceneLoadingEven
 
 		savedPatch ??= new Json.Patch();
 
-		var baseline = BuildCompositeBaselineFromFiles( sceneFiles, sceneFiles[0].Id );
+		// Use the saved scene ID for the baseline root so the patch applies correctly
+		var savedSceneId = Guid.TryParse( saveRoot["SceneId"]?.GetValue<string>(), out var parsedId )
+			? parsedId
+			: sceneFiles[0].Id;
+
+		var baseline = BuildCompositeBaselineFromFiles( sceneFiles, savedSceneId );
 		if ( baseline is null )
 		{
 			Log.Warning( "SaveSystem: Failed to build baseline from scene sources." );

--- a/Code/UI/Components/MenuPanel.razor
+++ b/Code/UI/Components/MenuPanel.razor
@@ -10,7 +10,7 @@
         <div class="background" @onmousedown=@Close @onclick=@Close></div>
     }
 
-    <div class="inner @( _submenuOpensLeft ? "opens-left" : "" )">
+    <div class="inner @( _submenuOpensLeft && _options.Any( o => o.SubmenuBuilder != null ) ? "opens-left" : "" )">
 
         @foreach ( var option in _options )
         {

--- a/Code/UI/ContextMenu/ContextMenuHost.razor
+++ b/Code/UI/ContextMenu/ContextMenuHost.razor
@@ -5,7 +5,7 @@
 @attribute [SpawnMenuHost.SpawnMenuMode]
 @attribute [Icon("🔍")]
 @attribute [Title("Inspect")]
-@attribute [Order( -50 )]
+@attribute [Order( 500 )]
 
 <root>
 	

--- a/Code/UI/ContextMenu/ContextMenuHost.razor
+++ b/Code/UI/ContextMenu/ContextMenuHost.razor
@@ -68,6 +68,9 @@
 
     void DrawHandles()
     {
+		if ( Scene?.Camera is not { IsValid: true } )
+			return;
+
         var objects = Scene.FindInPhysics(new Sphere( Scene.Camera.WorldPosition, 1000 ));
         var rootObjects = objects.Select( x => x.Network?.RootGameObject ).Where( x => x.IsValid() ).Distinct();
 

--- a/Code/UI/Controls/StringQueryPopup.razor
+++ b/Code/UI/Controls/StringQueryPopup.razor
@@ -15,10 +15,13 @@
             <h3>@Prompt</h3>
         }
 
-        <TextEntry class="menu-input" Placeholder=@Placeholder Value:bind=@Value />
+        @if ( ShowInput )
+        {
+            <TextEntry class="menu-input" Placeholder=@Placeholder Value:bind=@Value />
+        }
 
         <span class="grow">
-            <Button Text=@ConfirmLabel Icon="check" class="menu-action primary" Disabled=@(string.IsNullOrWhiteSpace( Value )) @onclick=@OnConfirmClick />
+            <Button Text=@ConfirmLabel Icon="check" class="menu-action primary" Disabled=@(ShowInput && string.IsNullOrWhiteSpace( Value )) @onclick=@OnConfirmClick />
             <Button Text="Cancel" Icon="close" class="menu-action primary" @onclick=@(() => Delete()) />
         </span>
     </div>
@@ -42,6 +45,9 @@
     /// <summary>Pre-filled value in the text entry.</summary>
     public string InitialValue { get; set; } = "";
 
+    /// <summary>When false, hides the text entry — acts as a simple confirm/deny dialog.</summary>
+    public bool ShowInput { get; set; } = true;
+
     /// <summary>Called with the trimmed string when the user confirms.</summary>
     public Action<string> OnConfirm { get; set; }
 
@@ -55,8 +61,8 @@
 
     void OnConfirmClick()
     {
-        if ( string.IsNullOrWhiteSpace( Value ) ) return;
-        OnConfirm?.Invoke( Value.Trim() );
+        if ( ShowInput && string.IsNullOrWhiteSpace( Value ) ) return;
+        OnConfirm?.Invoke( Value?.Trim() ?? "" );
         Delete();
     }
 

--- a/Code/UI/SpawnMenu/SaveMenu.razor
+++ b/Code/UI/SpawnMenu/SaveMenu.razor
@@ -5,31 +5,41 @@
 @attribute [SpawnMenuHost.SpawnMenuMode]
 @attribute [Icon( "💾" )]
 @attribute [Title( "Saves" )]
-@attribute [Order( 500 )]
+@attribute [Order( 150 )]
 
 <root>
-    <div class="save-menu">
-
-        <div class="save-input">
-            <TextEntry @ref="SaveNameEntry" Placeholder="Enter save name..." @onsubmit="@OnSave"></TextEntry>
-            <button @onclick="@OnSave">Save</button>
-        </div>
-
-        <div class="save-list">
+    <div class="save-window">
+        <div class="save-header">💾 Saves</div>
+        <div class="body">
+            @if ( !SaveFiles.Any() )
+            {
+                <div class="empty-state">No saves yet.</div>
+            }
             @foreach ( var save in SaveFiles )
             {
-                <div class="save-item">
-                    <div class="save-info" @onclick="@(() => LoadSave( save.FileName ))">
-                        <div class="save-name">@save.DisplayName</div>
-                        <div class="save-filename">@save.FileName</div>
+                var s = save;
+                <div class="save-card"
+                     @onclick="@(() => ConfirmLoad( s ))"
+                     @onmousedown="@((PanelEvent e) => OnCardMouseDown( s, e ))">
+                    @if ( s.Thumbnail != null )
+                    {
+                        <Image class="save-thumb" Texture="@s.Thumbnail" />
+                    }
+                    <div class="save-info @(s.Thumbnail == null ? "save-info--padded" : "")">
+                        <label class="save-name">@s.DisplayName</label>
+                        @if ( !string.IsNullOrEmpty( s.Timestamp ) )
+                        {
+                            <label class="save-timestamp">@s.Timestamp</label>
+                        }
                     </div>
-                    <div class="save-delete" @onclick="@(() => DeleteSave( save.FileName ))">
-                        <i>delete</i>
-                    </div>
+                    <div class="save-dots">⋮</div>
                 </div>
             }
         </div>
-
+        <div class="footer">
+            <TextEntry @ref="SaveNameEntry" Placeholder="Save name..." @onsubmit="@OnSave"></TextEntry>
+            <button @onclick="@OnSave">💾 Save</button>
+        </div>
     </div>
 </root>
 
@@ -38,7 +48,7 @@
     TextEntry SaveNameEntry;
     List<SaveFileEntry> SaveFiles = new();
 
-    record SaveFileEntry( string FileName, string DisplayName );
+    record SaveFileEntry( string FileName, string DisplayName, string Timestamp, Texture Thumbnail );
 	static string SavesPath => "saves";
 
     protected override void OnAfterTreeRender( bool firstTime )
@@ -62,28 +72,89 @@
         {
 			var filePath = $"{SavesPath}/{file}";
             var displayName = file;
+            string timestamp = null;
+            Texture thumbnail = null;
 
             var metadata = SaveSystem.GetFileMetadata( filePath );
-            if ( metadata != null && metadata.TryGetValue( "Name", out var name ) )
+            if ( metadata != null )
             {
-                displayName = name.ToString();
+                if ( metadata.TryGetValue( "Title", out var name ) )
+                    displayName = name;
+                if ( metadata.TryGetValue( "Timestamp", out var ts ) )
+                    timestamp = ts;
             }
 
-            SaveFiles.Add( new SaveFileEntry( file, displayName ) );
+            var thumbPath = $"{SavesPath}/{System.IO.Path.GetFileNameWithoutExtension( file )}.thumb.png";
+            if ( FileSystem.Data.FileExists( thumbPath ) )
+            {
+                thumbnail = Texture.Load( FileSystem.Data, thumbPath );
+            }
+
+            SaveFiles.Add( new SaveFileEntry( file, displayName, timestamp, thumbnail ) );
         }
 
         StateHasChanged();
     }
 
+    void OnCardMouseDown( SaveFileEntry save, PanelEvent e )
+    {
+        if ( e is MousePanelEvent { MouseButton: MouseButtons.Right } me )
+        {
+            me.StopPropagation();
+            var menu = MenuPanel.Open( this );
+            menu.AddOption( "download", "Load Save", () => ConfirmLoad( save ) );
+            menu.AddOption( "delete", "Delete", () => ConfirmDelete( save ) );
+        }
+    }
+
+    void ConfirmLoad( SaveFileEntry save )
+    {
+        var popup = new StringQueryPopup
+        {
+            Title = "Load Save",
+            Prompt = $"Load \"{save.DisplayName}\"? Unsaved changes will be lost.",
+            ConfirmLabel = "Load",
+            ShowInput = false,
+            OnConfirm = _ => LoadSave( save.FileName ),
+            Parent = FindPopupPanel()
+        };
+    }
+
+    void ConfirmDelete( SaveFileEntry save )
+    {
+        var popup = new StringQueryPopup
+        {
+            Title = "Delete Save",
+            Prompt = $"Are you sure you want to delete \"{save.DisplayName}\"?",
+            ConfirmLabel = "Delete",
+            ShowInput = false,
+            OnConfirm = _ => DeleteSave( save.FileName ),
+            Parent = FindPopupPanel()
+        };
+    }
     void OnSave()
     {
         var saveName = SaveNameEntry?.Text?.Trim();
+
         if ( string.IsNullOrEmpty( saveName ) )
             return;
 
-		var fileName = $"{SavesPath}/{saveName}.sav";
+        var now = DateTime.Now;
+        var timeString = now.ToString( "yyyy-MM-dd HH:mm:ss" );
+        var baseName = now.ToString( "yyyy-MM-dd-HH-mm-ss" );
+		var fileName = $"{SavesPath}/{baseName}.sav";
 
-        SaveSystem.Current.SetMetadata( "Name", DateTime.Now.ToString( "yyyy-MM-dd HH:mm:ss" ) );
+        // Capture a 256x144 (16:9) thumbnail from the scene camera
+        var camera = Game.ActiveScene?.Camera;
+        if ( camera.IsValid() )
+        {
+            var bitmap = new Bitmap( 256, 144 );
+            camera.RenderToBitmap( bitmap );
+            FileSystem.Data.WriteAllBytes( $"{SavesPath}/{baseName}.thumb.png", bitmap.ToPng() );
+        }
+
+        SaveSystem.Current.SetMetadata( "Timestamp", timeString );
+        SaveSystem.Current.SetMetadata( "Title", saveName );
         SaveSystem.Current.Save( fileName );
 
         SaveNameEntry.Text = "";
@@ -98,6 +169,9 @@
     void DeleteSave( string fileName )
     {
 		FileSystem.Data.DeleteFile( $"{SavesPath}/{fileName}" );
+        var thumbPath = $"{SavesPath}/{System.IO.Path.GetFileNameWithoutExtension( fileName )}.thumb.png";
+        if ( FileSystem.Data.FileExists( thumbPath ) )
+            FileSystem.Data.DeleteFile( thumbPath );
         RefreshSaveList();
     }
 }

--- a/Code/UI/SpawnMenu/SaveMenu.razor
+++ b/Code/UI/SpawnMenu/SaveMenu.razor
@@ -8,7 +8,6 @@
 @attribute [Order( 500 )]
 
 <root>
-
     <div class="save-menu">
 
         <div class="save-input">
@@ -32,7 +31,6 @@
         </div>
 
     </div>
-
 </root>
 
 @code
@@ -94,7 +92,7 @@
 
     void LoadSave( string fileName )
     {
-		SaveSystem.Current.Load( $"{SavesPath}/{fileName}" );
+		_ = SaveSystem.Current.Load( $"{SavesPath}/{fileName}" );
     }
 
     void DeleteSave( string fileName )

--- a/Code/UI/SpawnMenu/SaveMenu.razor
+++ b/Code/UI/SpawnMenu/SaveMenu.razor
@@ -41,6 +41,7 @@
     List<SaveFileEntry> SaveFiles = new();
 
     record SaveFileEntry( string FileName, string DisplayName );
+	static string SavesPath => "saves";
 
     protected override void OnAfterTreeRender( bool firstTime )
     {
@@ -54,20 +55,20 @@
     {
         SaveFiles.Clear();
 
-        if ( !FileSystem.Data.DirectoryExists( "saves" ) )
+		if ( !FileSystem.Data.DirectoryExists( SavesPath ) )
         {
-            FileSystem.Data.CreateDirectory( "saves" );
+			FileSystem.Data.CreateDirectory( SavesPath );
         }
 
-        foreach ( var file in FileSystem.Data.FindFile( "saves", "*.sav" ) )
+		foreach ( var file in FileSystem.Data.FindFile( SavesPath, "*.sav" ) )
         {
-            var filePath = $"saves/{file}";
+			var filePath = $"{SavesPath}/{file}";
             var displayName = file;
 
-            var metadata = SaveSystem.GetMetadata( filePath );
+            var metadata = SaveSystem.GetFileMetadata( filePath );
             if ( metadata != null && metadata.TryGetValue( "Name", out var name ) )
             {
-                displayName = name;
+                displayName = name.ToString();
             }
 
             SaveFiles.Add( new SaveFileEntry( file, displayName ) );
@@ -82,10 +83,10 @@
         if ( string.IsNullOrEmpty( saveName ) )
             return;
 
-        var fileName = $"saves/{saveName}.sav";
+		var fileName = $"{SavesPath}/{saveName}.sav";
 
-        SaveSystem.SetMetadata( "Name", DateTime.Now.ToString( "yyyy-MM-dd HH:mm:ss" ) );
-        SaveSystem.Save( fileName );
+        SaveSystem.Current.SetMetadata( "Name", DateTime.Now.ToString( "yyyy-MM-dd HH:mm:ss" ) );
+        SaveSystem.Current.Save( fileName );
 
         SaveNameEntry.Text = "";
         RefreshSaveList();
@@ -93,12 +94,12 @@
 
     void LoadSave( string fileName )
     {
-        SaveSystem.Load( $"saves/{fileName}" );
+		SaveSystem.Current.Load( $"{SavesPath}/{fileName}" );
     }
 
     void DeleteSave( string fileName )
     {
-        FileSystem.Data.DeleteFile( $"saves/{fileName}" );
+		FileSystem.Data.DeleteFile( $"{SavesPath}/{fileName}" );
         RefreshSaveList();
     }
 }

--- a/Code/UI/SpawnMenu/SaveMenu.razor
+++ b/Code/UI/SpawnMenu/SaveMenu.razor
@@ -2,7 +2,7 @@
 @using Sandbox.UI;
 @namespace Sandbox
 @inherits Panel
-@attribute [SpawnMenuHost.SpawnMenuMode]
+@attribute [SpawnMenuHost.SpawnMenuMode<SpawnMenuHost.HostOnly>]
 @attribute [Icon( "💾" )]
 @attribute [Title( "Saves" )]
 @attribute [Order( 150 )]

--- a/Code/UI/SpawnMenu/SaveMenu.razor
+++ b/Code/UI/SpawnMenu/SaveMenu.razor
@@ -1,0 +1,104 @@
+﻿@using Sandbox;
+@using Sandbox.UI;
+@namespace Sandbox
+@inherits Panel
+@attribute [SpawnMenuHost.SpawnMenuMode]
+@attribute [Icon( "💾" )]
+@attribute [Title( "Saves" )]
+@attribute [Order( 500 )]
+
+<root>
+
+    <div class="save-menu">
+
+        <div class="save-input">
+            <TextEntry @ref="SaveNameEntry" Placeholder="Enter save name..." @onsubmit="@OnSave"></TextEntry>
+            <button @onclick="@OnSave">Save</button>
+        </div>
+
+        <div class="save-list">
+            @foreach ( var save in SaveFiles )
+            {
+                <div class="save-item">
+                    <div class="save-info" @onclick="@(() => LoadSave( save.FileName ))">
+                        <div class="save-name">@save.DisplayName</div>
+                        <div class="save-filename">@save.FileName</div>
+                    </div>
+                    <div class="save-delete" @onclick="@(() => DeleteSave( save.FileName ))">
+                        <i>delete</i>
+                    </div>
+                </div>
+            }
+        </div>
+
+    </div>
+
+</root>
+
+@code
+{
+    TextEntry SaveNameEntry;
+    List<SaveFileEntry> SaveFiles = new();
+
+    record SaveFileEntry( string FileName, string DisplayName );
+
+    protected override void OnAfterTreeRender( bool firstTime )
+    {
+        if ( firstTime )
+        {
+            RefreshSaveList();
+        }
+    }
+
+    void RefreshSaveList()
+    {
+        SaveFiles.Clear();
+
+        if ( !FileSystem.Data.DirectoryExists( "saves" ) )
+        {
+            FileSystem.Data.CreateDirectory( "saves" );
+        }
+
+        foreach ( var file in FileSystem.Data.FindFile( "saves", "*.sav" ) )
+        {
+            var filePath = $"saves/{file}";
+            var displayName = file;
+
+            var metadata = SaveSystem.GetMetadata( filePath );
+            if ( metadata != null && metadata.TryGetValue( "Name", out var name ) )
+            {
+                displayName = name;
+            }
+
+            SaveFiles.Add( new SaveFileEntry( file, displayName ) );
+        }
+
+        StateHasChanged();
+    }
+
+    void OnSave()
+    {
+        var saveName = SaveNameEntry?.Text?.Trim();
+        if ( string.IsNullOrEmpty( saveName ) )
+            return;
+
+        var fileName = $"saves/{saveName}.sav";
+
+        SaveSystem.SetMetadata( "Name", DateTime.Now.ToString( "yyyy-MM-dd HH:mm:ss" ) );
+        SaveSystem.Save( fileName );
+
+        SaveNameEntry.Text = "";
+        RefreshSaveList();
+    }
+
+    void LoadSave( string fileName )
+    {
+        SaveSystem.Load( $"saves/{fileName}" );
+    }
+
+    void DeleteSave( string fileName )
+    {
+        FileSystem.Data.DeleteFile( $"saves/{fileName}" );
+        RefreshSaveList();
+    }
+}

--- a/Code/UI/SpawnMenu/SaveMenu.razor.scss
+++ b/Code/UI/SpawnMenu/SaveMenu.razor.scss
@@ -297,9 +297,9 @@ VirtualGrid
 
     .save-filename
     {
-        color: #fff8;
+        color: #fffe;
         font-size: 12px;
-        font-weight: 400;
+        font-weight: 600;
     }
 
     .save-delete

--- a/Code/UI/SpawnMenu/SaveMenu.razor.scss
+++ b/Code/UI/SpawnMenu/SaveMenu.razor.scss
@@ -1,327 +1,176 @@
+@import "/UI/Theme.scss";
 
-SpawnMenu
+SaveMenu
 {
     width: 100%;
     height: 100%;
-    color: #cdf;
-    justify-content: center;
-    font-family: Poppins;
-    font-size: 14px;
-    font-weight: 600;
-    z-index: 1000;
-    backdrop-filter: brightness( 0.4 ) contrast( 0.7 ) saturate( 0.7 );
-}
-
-SpawnMenu .container
-{
-    width: 100%;
-    height: 100%;
-    max-width: 1900px;
-}
-
-SpawnMenu .container .spawnmenuleft
-{
-    transform: translateX( -100px );
-    transition: all 0.2s ease-in;
-}
-
-SpawnMenu .container .spawnmenuright
-{
-    transform: translateX( 100px );
-    transition: all 0.2s ease-in;
-}
-
-SpawnMenuHost.open SpawnMenu
-{
-    .container .spawnmenuleft
-    {
-        transform: translateX( 0px );
-        transition: all 0.1s ease-out;
-    }
-
-    .container .spawnmenuright
-    {
-        transform: translateX( 0px );
-        transition: all 0.1s ease-out;
-    }
-}
-
-.container .spawnmenuleft
-{
-    flex-grow: 1;
-    padding: 128px 64px;
-    padding-right: 16px;
-
-    PanelSwitcher
-    {
-        padding-bottom: 128px;
-    }
-}
-
-.container .spawnmenuright
-{
-    width: 700px;
-    flex-shrink: 0;
-    flex-grow: 0;
-    padding: 128px 64px;
-    padding-left: 16px;
-}
-
-.container > .spawnmenuleft,
-.container > .spawnmenuright
-{
     flex-direction: column;
+    align-items: center;
+    justify-content: flex-end;
+    padding-bottom: calc( $deadzone-y + 96px + 8px );
 }
 
-
-.container > .spawnmenuleft > .body,
-.container > .spawnmenuright > .body
+.save-window
 {
-    border-radius: 8px;
-    flex-grow: 1;
-}
-
-.tabs
-{
-    font-size: 14px;
-    color: white;
-    font-weight: 650;
-    font-family: Poppins;
-    margin-left: 8px;
-    z-index: 10;
-    flex-shrink: 0;
-}
-
-.tabs > *
-{
-    padding: 0.5rem 1rem;
-    cursor: pointer;
-    color: #D1D7E3AA;
-    border-radius: 8px 8px 0 0;
-    background-color: #0c202faa;
-    opacity: 1;
-    border-right: 1px solid #0004;
-    gap: 0.4rem;
-}
-
-.tabs > *:hover
-{
-    color: #cdf;
-    sound-in: ui.hover;
-}
-
-.tabs > *:active
-{
-    color: #fff;
-    sound-in: ui.select;
-}
-
-.tabs > *.active
-{
-    opacity: 1;
-    color: #fff;
-    cursor: pointer;
-    background-color: #0c202fcc;
-    pointer-events: none;
+    background-color: $menu-panel-bg;
     backdrop-filter: blur( 8px );
-}
-
-
-.container > .spawnmenuleft > .body
-{
-    position: relative;
-}
-
-
-.container > .spawnmenuleft > .body > *
-{
-    position: absolute;
-    height: 100%;
-    width: 100%;
-}
-
-.container > .spawnmenuleft > .body > .hidden
-{
-    opacity: 0;
-    pointer-events: none;
-    transition: all 0.1s linear;
-    transform: translateY( 20px );
-}
-
-.container > .spawnmenuleft > .body > .active
-{
-    opacity: 1;
-    transition: all 0.1s linear;
-    transform: translateY( 0px );
-}
-
-.container > .spawnmenuleft,
-.container > .spawnmenuright
-{
-    > .body
-    {
-        background-color: #0c202fcc;
-        backdrop-filter: blur( 2px );
-    }
-}
-
-
-.menuinner
-{
-    background-color: #13161a88;
+    border: 1px solid $menu-surface-soft;
     border-radius: 8px;
-}
-
-VirtualGrid
-{
-    width: 100%;
-    height: 100%;
-    gap: 5px;
-
-    .cell
-    {
-        background-color: #7771;
-        cursor: pointer;
-
-        &:hover
-        {
-            background-color: #7773;
-        }
-
-        &:active
-        {
-            background-color: #08f;
-            padding: 2px;
-        }
-    }
-}
-
-// Save Menu Styles
-.save-menu
-{
+    padding: 1rem;
+    width: 500px;
+    max-height: 400px;
     flex-direction: column;
-    padding: 160px;
-    gap: 16px;
-    height: 100%;
-    pointer-events: all;
-}
 
-.save-input
-{
-    flex-shrink: 0;
-    gap: 8px;
-
-    TextEntry
+    .save-header
     {
-        flex-grow: 1;
-        padding: 10px 14px;
-        background-color: #0004;
-        border-radius: 6px;
-        color: white;
-        font-size: 14px;
-        border: 1px solid #fff1;
-        min-width: 300px;
-
-        &:focus
-        {
-            border: 1px solid #08f;
-            background-color: #0006;
-        }
+        font-size: 13px;
+        font-weight: 700;
+        color: rgba( white, 0.5 );
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        padding-bottom: 8px;
+        flex-shrink: 0;
     }
 
-    button
+    .body
     {
-        padding: 10px 20px;
-        background-color: #08f;
-        border-radius: 6px;
-        color: white;
-        font-weight: 600;
-        cursor: pointer;
+        flex-direction: column;
+        flex-grow: 1;
+        overflow-y: scroll;
+        gap: 4px;
+    }
+
+    .empty-state
+    {
+        text-align: center;
+        color: rgba( white, 0.35 );
+        font-size: 12px;
+        padding: 1rem 0;
+    }
+
+    .footer
+    {
+        flex-direction: row;
+        gap: 6px;
+        padding-top: 8px;
         flex-shrink: 0;
 
-        &:hover
+        TextEntry
         {
-            background-color: #09f;
+            flex-grow: 1;
+            padding: 6px 10px;
+            background-color: rgba( white, 0.05 );
+            border-radius: 6px;
+            font-size: 13px;
+            border: 1px solid rgba( white, 0.08 );
+
+            &:focus
+            {
+                border-color: $color-accent;
+                background-color: rgba( white, 0.08 );
+            }
         }
 
-        &:active
+        button
         {
-            background-color: #07d;
+            padding: 6px 14px;
+            background-color: $menu-accent-soft;
+            border: 1px solid $menu-accent;
+            border-radius: 6px;
+            color: white;
+            font-size: 13px;
+            font-weight: 600;
+            cursor: pointer;
+            flex-shrink: 0;
+
+            &:hover
+            {
+                background-color: rgba( $color-accent, 0.3 );
+                sound-in: ui.hover;
+            }
+
+            &:active
+            {
+                background-color: $menu-accent;
+            }
         }
     }
 }
 
-.save-list
-{
-    flex-direction: column;
-    gap: 8px;
-    overflow-y: scroll;
-    flex-grow: 1;
-}
-
-.save-item
+.save-card
 {
     flex-direction: row;
-    background-color: #0003;
-    border-radius: 6px;
-    border: 1px solid #fff1;
+    align-items: center;
+    background-color: rgba( white, 0.04 );
+    border-radius: 4px;
+    overflow: hidden;
+    cursor: pointer;
     flex-shrink: 0;
-    align-items: stretch;
+    gap: 10px;
 
     &:hover
     {
-        background-color: #0005;
-        border: 1px solid #fff2;
+        background-color: rgba( white, 0.08 );
+        sound-in: ui.hover;
+
+        .save-name { color: white; }
+    }
+
+    &:active
+    {
+        background-color: rgba( white, 0.12 );
+    }
+
+    .save-thumb
+    {
+        width: 96px;
+        height: 54px;
+        flex-shrink: 0;
+        background-size: cover;
+        background-position: center;
+        background-color: rgba( white, 0.06 );
     }
 
     .save-info
     {
         flex-direction: column;
-        padding: 12px 16px;
-        gap: 4px;
+        gap: 2px;
         flex-grow: 1;
-        cursor: pointer;
+        padding: 8px 8px 8px 10px;
 
-        &:active
+        &--padded
         {
-            background-color: #08f3;
+            padding: 8px 10px;
         }
     }
 
     .save-name
     {
-        color: white;
-        font-size: 14px;
+        font-size: 13px;
+        color: rgba( white, 0.8 );
         font-weight: 600;
     }
 
-    .save-filename
+    .save-timestamp
     {
-        color: #fffe;
-        font-size: 12px;
-        font-weight: 600;
+        font-size: 11px;
+        color: rgba( white, 0.35 );
+        font-weight: 400;
     }
 
-    .save-delete
+    .save-dots
     {
-        padding: 12px 16px;
-        cursor: pointer;
-        color: #fff6;
+        font-size: 18px;
+        color: rgba( white, 0.25 );
+        padding: 0 10px;
+        flex-shrink: 0;
         align-items: center;
         justify-content: center;
-        font-family: Material Icons;
-        font-size: 18px;
+        letter-spacing: -2px;
+    }
 
-        &:hover
-        {
-            color: #f55;
-            background-color: #f551;
-        }
-
-        &:active
-        {
-            color: #fff;
-            background-color: #f55;
-        }
+    &:hover .save-dots
+    {
+        color: rgba( white, 0.6 );
     }
 }

--- a/Code/UI/SpawnMenu/SaveMenu.razor.scss
+++ b/Code/UI/SpawnMenu/SaveMenu.razor.scss
@@ -1,0 +1,327 @@
+
+SpawnMenu
+{
+    width: 100%;
+    height: 100%;
+    color: #cdf;
+    justify-content: center;
+    font-family: Poppins;
+    font-size: 14px;
+    font-weight: 600;
+    z-index: 1000;
+    backdrop-filter: brightness( 0.4 ) contrast( 0.7 ) saturate( 0.7 );
+}
+
+SpawnMenu .container
+{
+    width: 100%;
+    height: 100%;
+    max-width: 1900px;
+}
+
+SpawnMenu .container .spawnmenuleft
+{
+    transform: translateX( -100px );
+    transition: all 0.2s ease-in;
+}
+
+SpawnMenu .container .spawnmenuright
+{
+    transform: translateX( 100px );
+    transition: all 0.2s ease-in;
+}
+
+SpawnMenuHost.open SpawnMenu
+{
+    .container .spawnmenuleft
+    {
+        transform: translateX( 0px );
+        transition: all 0.1s ease-out;
+    }
+
+    .container .spawnmenuright
+    {
+        transform: translateX( 0px );
+        transition: all 0.1s ease-out;
+    }
+}
+
+.container .spawnmenuleft
+{
+    flex-grow: 1;
+    padding: 128px 64px;
+    padding-right: 16px;
+
+    PanelSwitcher
+    {
+        padding-bottom: 128px;
+    }
+}
+
+.container .spawnmenuright
+{
+    width: 700px;
+    flex-shrink: 0;
+    flex-grow: 0;
+    padding: 128px 64px;
+    padding-left: 16px;
+}
+
+.container > .spawnmenuleft,
+.container > .spawnmenuright
+{
+    flex-direction: column;
+}
+
+
+.container > .spawnmenuleft > .body,
+.container > .spawnmenuright > .body
+{
+    border-radius: 8px;
+    flex-grow: 1;
+}
+
+.tabs
+{
+    font-size: 14px;
+    color: white;
+    font-weight: 650;
+    font-family: Poppins;
+    margin-left: 8px;
+    z-index: 10;
+    flex-shrink: 0;
+}
+
+.tabs > *
+{
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+    color: #D1D7E3AA;
+    border-radius: 8px 8px 0 0;
+    background-color: #0c202faa;
+    opacity: 1;
+    border-right: 1px solid #0004;
+    gap: 0.4rem;
+}
+
+.tabs > *:hover
+{
+    color: #cdf;
+    sound-in: ui.hover;
+}
+
+.tabs > *:active
+{
+    color: #fff;
+    sound-in: ui.select;
+}
+
+.tabs > *.active
+{
+    opacity: 1;
+    color: #fff;
+    cursor: pointer;
+    background-color: #0c202fcc;
+    pointer-events: none;
+    backdrop-filter: blur( 8px );
+}
+
+
+.container > .spawnmenuleft > .body
+{
+    position: relative;
+}
+
+
+.container > .spawnmenuleft > .body > *
+{
+    position: absolute;
+    height: 100%;
+    width: 100%;
+}
+
+.container > .spawnmenuleft > .body > .hidden
+{
+    opacity: 0;
+    pointer-events: none;
+    transition: all 0.1s linear;
+    transform: translateY( 20px );
+}
+
+.container > .spawnmenuleft > .body > .active
+{
+    opacity: 1;
+    transition: all 0.1s linear;
+    transform: translateY( 0px );
+}
+
+.container > .spawnmenuleft,
+.container > .spawnmenuright
+{
+    > .body
+    {
+        background-color: #0c202fcc;
+        backdrop-filter: blur( 2px );
+    }
+}
+
+
+.menuinner
+{
+    background-color: #13161a88;
+    border-radius: 8px;
+}
+
+VirtualGrid
+{
+    width: 100%;
+    height: 100%;
+    gap: 5px;
+
+    .cell
+    {
+        background-color: #7771;
+        cursor: pointer;
+
+        &:hover
+        {
+            background-color: #7773;
+        }
+
+        &:active
+        {
+            background-color: #08f;
+            padding: 2px;
+        }
+    }
+}
+
+// Save Menu Styles
+.save-menu
+{
+    flex-direction: column;
+    padding: 160px;
+    gap: 16px;
+    height: 100%;
+    pointer-events: all;
+}
+
+.save-input
+{
+    flex-shrink: 0;
+    gap: 8px;
+
+    TextEntry
+    {
+        flex-grow: 1;
+        padding: 10px 14px;
+        background-color: #0004;
+        border-radius: 6px;
+        color: white;
+        font-size: 14px;
+        border: 1px solid #fff1;
+        min-width: 300px;
+
+        &:focus
+        {
+            border: 1px solid #08f;
+            background-color: #0006;
+        }
+    }
+
+    button
+    {
+        padding: 10px 20px;
+        background-color: #08f;
+        border-radius: 6px;
+        color: white;
+        font-weight: 600;
+        cursor: pointer;
+        flex-shrink: 0;
+
+        &:hover
+        {
+            background-color: #09f;
+        }
+
+        &:active
+        {
+            background-color: #07d;
+        }
+    }
+}
+
+.save-list
+{
+    flex-direction: column;
+    gap: 8px;
+    overflow-y: scroll;
+    flex-grow: 1;
+}
+
+.save-item
+{
+    flex-direction: row;
+    background-color: #0003;
+    border-radius: 6px;
+    border: 1px solid #fff1;
+    flex-shrink: 0;
+    align-items: stretch;
+
+    &:hover
+    {
+        background-color: #0005;
+        border: 1px solid #fff2;
+    }
+
+    .save-info
+    {
+        flex-direction: column;
+        padding: 12px 16px;
+        gap: 4px;
+        flex-grow: 1;
+        cursor: pointer;
+
+        &:active
+        {
+            background-color: #08f3;
+        }
+    }
+
+    .save-name
+    {
+        color: white;
+        font-size: 14px;
+        font-weight: 600;
+    }
+
+    .save-filename
+    {
+        color: #fff8;
+        font-size: 12px;
+        font-weight: 400;
+    }
+
+    .save-delete
+    {
+        padding: 12px 16px;
+        cursor: pointer;
+        color: #fff6;
+        align-items: center;
+        justify-content: center;
+        font-family: Material Icons;
+        font-size: 18px;
+
+        &:hover
+        {
+            color: #f55;
+            background-color: #f551;
+        }
+
+        &:active
+        {
+            color: #fff;
+            background-color: #f55;
+        }
+    }
+}

--- a/Code/UI/SpawnMenuHost.razor
+++ b/Code/UI/SpawnMenuHost.razor
@@ -97,17 +97,31 @@
         if ( PanelSwitcher == null )
             return;
 
-        // Make sure we've created all the modes, create SpawnMenu first so it's selected by default
-        foreach ( var type in Game.TypeLibrary.GetTypesWithAttribute<SpawnMenuMode>().OrderBy( x => x.Type.Name != "SpawnMenu" ) )
+        var modes = Game.TypeLibrary.GetTypesWithAttribute<SpawnMenuMode>().OrderBy( x => x.Type.Name != "SpawnMenu" ).ToList();
+
+        // Remove panels whose condition is no longer met
+        foreach ( var child in PanelSwitcher.Children.ToList() )
         {
-            if (PanelSwitcher.Children.Any(x => x.GetType() == type.Type.TargetType)) continue;
-
-            var panel = type.Type.Create<Panel>();
-            if (panel == null) continue;
-
-            PanelSwitcher.AddChild(panel);
+            var mode = modes.FirstOrDefault( m => m.Type.TargetType == child.GetType() );
+            if ( mode.Type != null && !mode.Attribute.CheckCondition() )
+            {
+                if ( PanelSwitcher.ActivePanel == child )
+                    SwitchMode( "SpawnMenu" );
+                child.Delete();
+            }
         }
 
+        // Create panels for modes whose condition is met
+        foreach ( var type in modes )
+        {
+            if ( !type.Attribute.CheckCondition() ) continue;
+            if ( PanelSwitcher.Children.Any( x => x.GetType() == type.Type.TargetType ) ) continue;
+
+            var panel = type.Type.Create<Panel>();
+            if ( panel == null ) continue;
+
+            PanelSwitcher.AddChild( panel );
+        }
     }
 
     public static void SwitchMode( string modeName, bool remember = true )
@@ -134,8 +148,23 @@
         return host.PanelSwitcher.ActivePanel;
     }
 
-    public class SpawnMenuMode : System.Attribute
+    public interface ISpawnMenuCondition
     {
+        static abstract bool IsVisible();
     }
 
+    public class SpawnMenuMode : System.Attribute
+    {
+        public virtual bool CheckCondition() => true;
+    }
+
+    public class SpawnMenuMode<T> : SpawnMenuMode where T : ISpawnMenuCondition
+    {
+        public override bool CheckCondition() => T.IsVisible();
+    }
+
+    public class HostOnly : ISpawnMenuCondition
+    {
+        public static bool IsVisible() => Networking.IsHost;
+    }
 }

--- a/Code/UI/SpawnMenuModeBar.razor
+++ b/Code/UI/SpawnMenuModeBar.razor
@@ -13,6 +13,8 @@
 
         foreach ( var mode in Game.TypeLibrary.GetTypesWithAttribute<SpawnMenuHost.SpawnMenuMode>().OrderBy( x => x.Type.Order ) )
         {
+            if ( !mode.Attribute.CheckCondition() ) continue;
+
             var activeClass = mode.Type.TargetType == activeMode?.GetType() ? "active" : "";
 
             <div class="menu-mode-button @activeClass" @onclick="@( () => SpawnMenuHost.SwitchMode( mode.Type.Name ) )">


### PR DESCRIPTION
Resolves Facepunch/sandbox#4

After making some things in-engine public, this is now completely self-contained so we can iterate on it based on our needs before we move `SaveSystem` and `ISaveEvents` into the engine :)

# Changes

- Adds `SaveSystem.cs` which is a GameObjectSystem that can be used to save/load save states that are created by diffing the current scene's state against the base loaded scene(s)
- Adds `SaveMenu.razor` which is accessible via the Q menu to create/load saves
- Added `ISaveEvents` which fire before/after a save is created or loaded
- Updated `PlayerData.cs` so that the PlayerId is updated after loaded a save
- Updated `GameManager.cs` so it won't create a new player if one already exists (happens when loading a save)
- Make sure Scene.Camera is valid in ContextMenuHost (would trigger an NRE on the frame a save was loaded sometimes because the camera is re-created