### PR TITLE
Save tool mode properties as cookies

### DIFF
--- a/Code/UI/SpawnMenu/ToolsTab.razor
+++ b/Code/UI/SpawnMenu/ToolsTab.razor
@@ -73,6 +73,14 @@
 		toolgun.SetToolMode(t.ClassName);
 	}
 
+	protected override void OnVisibilityChanged()
+	{
+		if ( !IsVisible )
+		{
+			GetCurrentMode()?.SaveCookies();
+		}
+	}
+
 	ToolMode GetCurrentMode()
 	{
 		var localPlayer = Player.FindLocalPlayer();

--- a/Code/Utility/CookieSource.cs
+++ b/Code/Utility/CookieSource.cs
@@ -1,10 +1,5 @@
 ﻿using System.Text.Json;
-
-[AttributeUsage( AttributeTargets.Property )]
-public sealed class CookieAttribute : Attribute
-{
-	public string Name { get; init; }
-}
+using System.Text.Json.Serialization;
 
 public interface ICookieSource
 {
@@ -18,7 +13,8 @@ public static class CookieSourceExtensions
 		// TODO: maybe we want to support static properties too?
 
 		if ( property.IsStatic ) return false;
-		if ( !property.HasAttribute<CookieAttribute>() ) return false;
+		if ( !property.HasAttribute<PropertyAttribute>() ) return false;
+		if ( property.HasAttribute<JsonIgnoreAttribute>() ) return false;
 		if ( !property.CanWrite || !property.CanRead ) return false;
 
 		return true;
@@ -26,7 +22,7 @@ public static class CookieSourceExtensions
 
 	private static string GetCookieName( PropertyDescription property, string prefix )
 	{
-		var name = property.GetCustomAttribute<CookieAttribute>()?.Name ?? property.Name;
+		var name = property.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name ?? property.Name.ToLower();
 
 		return !string.IsNullOrEmpty( prefix ) ? $"{prefix}.{name}" : name;
 	}

--- a/Code/Utility/CookieSource.cs
+++ b/Code/Utility/CookieSource.cs
@@ -32,7 +32,7 @@ public static class CookieSourceExtensions
 
 	private static string GetCookieName( PropertyDescription property, string prefix )
 	{
-		var name = property.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name ?? property.Name.ToLower();
+		var name = property.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name ?? property.Name.ToLowerInvariant();
 
 		return !string.IsNullOrEmpty( prefix ) ? $"{prefix}.{name}" : name;
 	}

--- a/Code/Utility/CookieSource.cs
+++ b/Code/Utility/CookieSource.cs
@@ -1,11 +1,21 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Serialization;
 
+/// <summary>
+/// We want to save the properties of this instance as cookies.
+/// </summary>
 public interface ICookieSource
 {
+	/// <summary>
+	/// Prefix to put before the names of any cookies, without a trailing period.
+	/// For example: <c>"tool.balloon"</c>
+	/// </summary>
 	string CookiePrefix { get; }
 }
 
+/// <summary>
+/// Extension methods for <see cref="ICookieSource"/>.
+/// </summary>
 public static class CookieSourceExtensions
 {
 	private static bool IsCookieProperty( PropertyDescription property )
@@ -40,6 +50,10 @@ public static class CookieSourceExtensions
 				.Select( x => (GetCookieName( x, prefix ), x) );
 		}
 
+		/// <summary>
+		/// Saves any instance properties with a <see cref="PropertyAttribute"/>, excluding any
+		/// with <see cref="JsonIgnoreAttribute"/>, into <see cref="Game.Cookies"/>.
+		/// </summary>
 		public void SaveCookies()
 		{
 			foreach ( var (cookieName, property) in source.GetCookieProperties() )
@@ -57,6 +71,10 @@ public static class CookieSourceExtensions
 			}
 		}
 
+		/// <summary>
+		/// Loads any instance properties with a <see cref="PropertyAttribute"/>, excluding any
+		/// with <see cref="JsonIgnoreAttribute"/>, from <see cref="Game.Cookies"/>.
+		/// </summary>
 		public void LoadCookies()
 		{
 			foreach ( var (cookieName, property) in source.GetCookieProperties() )

--- a/Code/Utility/CookieSource.cs
+++ b/Code/Utility/CookieSource.cs
@@ -1,0 +1,83 @@
+﻿using System.Text.Json;
+
+[AttributeUsage( AttributeTargets.Property )]
+public sealed class CookieAttribute : Attribute
+{
+	public string Name { get; init; }
+}
+
+public interface ICookieSource
+{
+	string CookiePrefix { get; }
+}
+
+public static class CookieSourceExtensions
+{
+	private static bool IsCookieProperty( PropertyDescription property )
+	{
+		// TODO: maybe we want to support static properties too?
+
+		if ( property.IsStatic ) return false;
+		if ( !property.HasAttribute<CookieAttribute>() ) return false;
+		if ( !property.CanWrite || !property.CanRead ) return false;
+
+		return true;
+	}
+
+	private static string GetCookieName( PropertyDescription property, string prefix )
+	{
+		var name = property.GetCustomAttribute<CookieAttribute>()?.Name ?? property.Name;
+
+		return !string.IsNullOrEmpty( prefix ) ? $"{prefix}.{name}" : name;
+	}
+
+	extension( ICookieSource source )
+	{
+		private IEnumerable<(string CookieName, PropertyDescription Property)> GetCookieProperties()
+		{
+			var typeDesc = TypeLibrary.GetType( source.GetType() );
+			if ( typeDesc is null ) return [];
+
+			var prefix = source.CookiePrefix;
+
+			return typeDesc.Properties.Where( IsCookieProperty )
+				.Select( x => (GetCookieName( x, prefix ), x) );
+		}
+
+		public void SaveCookies()
+		{
+			foreach ( var (cookieName, property) in source.GetCookieProperties() )
+			{
+				try
+				{
+					var cookieValue = property.GetValue( source );
+
+					Game.Cookies.SetString( cookieName, JsonSerializer.Serialize( cookieValue, property.PropertyType ) );
+				}
+				catch ( Exception ex )
+				{
+					Log.Warning( ex, $"Exception while saving cookie \"{cookieName}\"." );
+				}
+			}
+		}
+
+		public void LoadCookies()
+		{
+			foreach ( var (cookieName, property) in source.GetCookieProperties() )
+			{
+				if ( !Game.Cookies.TryGetString( cookieName, out var jsonString ) ) continue;
+
+				try
+				{
+					var cookieValue = JsonSerializer.Deserialize( jsonString, property.PropertyType );
+
+					property.SetValue( source, cookieValue );
+				}
+				catch ( Exception ex )
+				{
+					Log.Warning( ex, $"Exception while loading cookie \"{cookieName}\"." );
+				}
+			}
+		}
+	}
+}

--- a/Code/Weapons/ToolGun/Modes/Balloon/Balloon.cs
+++ b/Code/Weapons/ToolGun/Modes/Balloon/Balloon.cs
@@ -10,17 +10,17 @@ public class Balloon : ToolMode
 	public string Definition { get; set; } = "entities/balloon/basic.bdef";
 
 	[Range( 0, 500 )]
-	[Property, Sync, Cookie]
+	[Property, Sync]
 	public float Length { get; set; } = 50.0f;
 
 	[Range( -10, 10 )]
-	[Property, Sync, Cookie]
+	[Property, Sync]
 	public float Force { get; set; } = 1.0f;
 
-	[Property, Sync, Cookie]
+	[Property, Sync]
 	public bool Rigid { get; set; } = false;
 
-	[Property, Sync, Cookie]
+	[Property, Sync]
 	public Color Tint { get; set; } = Color.White;
 
 	public override string Description => "#tool.hint.balloon.description";

--- a/Code/Weapons/ToolGun/Modes/Balloon/Balloon.cs
+++ b/Code/Weapons/ToolGun/Modes/Balloon/Balloon.cs
@@ -10,17 +10,17 @@ public class Balloon : ToolMode
 	public string Definition { get; set; } = "entities/balloon/basic.bdef";
 
 	[Range( 0, 500 )]
-	[Property, Sync]
+	[Property, Sync, Cookie]
 	public float Length { get; set; } = 50.0f;
 
 	[Range( -10, 10 )]
-	[Property, Sync]
+	[Property, Sync, Cookie]
 	public float Force { get; set; } = 1.0f;
 
-	[Property, Sync]
+	[Property, Sync, Cookie]
 	public bool Rigid { get; set; } = false;
 
-	[Property, Sync]
+	[Property, Sync, Cookie]
 	public Color Tint { get; set; } = Color.White;
 
 	public override string Description => "#tool.hint.balloon.description";

--- a/Code/Weapons/ToolGun/ToolMode.Cookies.cs
+++ b/Code/Weapons/ToolGun/ToolMode.Cookies.cs
@@ -1,4 +1,4 @@
 ﻿partial class ToolMode : ICookieSource
 {
-	public virtual string CookiePrefix => $"tool.{GetType().Name.ToLower()}";
+	public virtual string CookiePrefix => $"tool.{GetType().Name.ToLowerInvariant()}";
 }

--- a/Code/Weapons/ToolGun/ToolMode.Cookies.cs
+++ b/Code/Weapons/ToolGun/ToolMode.Cookies.cs
@@ -1,0 +1,4 @@
+﻿partial class ToolMode : ICookieSource
+{
+	public virtual string CookiePrefix => $"tool.{GetType().Name.ToLower()}";
+}

--- a/Code/Weapons/ToolGun/ToolMode.SnapGrid.cs
+++ b/Code/Weapons/ToolGun/ToolMode.SnapGrid.cs
@@ -14,7 +14,7 @@ public abstract partial class ToolMode
 
 	private Vector3? _lockedSnapTarget;
 
-	protected override void OnDisabled()
+	private void DisableSnapGrid()
 	{
 		SnapGrid?.Destroy();
 		SnapGrid = null;

--- a/Code/Weapons/ToolGun/ToolMode.cs
+++ b/Code/Weapons/ToolGun/ToolMode.cs
@@ -48,6 +48,24 @@ public abstract partial class ToolMode : Component, IToolInfo
 		TypeDescription = TypeLibrary.GetType( GetType() );
 	}
 
+	protected override void OnEnabled()
+	{
+		if ( Network.IsOwner )
+		{
+			this.LoadCookies();
+		}
+	}
+
+	protected override void OnDisabled()
+	{
+		DisableSnapGrid();
+
+		if ( Network.IsOwner )
+		{
+			this.SaveCookies();
+		}
+	}
+
 	public virtual void DrawScreen( Rect rect, HudPainter paint )
 	{
 		var t = $"{TypeDescription.Icon} {TypeDescription.Title}";

--- a/Code/Weapons/ToolGun/Toolgun.cs
+++ b/Code/Weapons/ToolGun/Toolgun.cs
@@ -92,12 +92,6 @@ public partial class Toolgun : ScreenWeapon
 		if ( newMode == currentMode )
 			return;
 
-		if ( Network.IsOwner )
-		{
-			currentMode?.SaveCookies();
-			newMode.LoadCookies();
-		}
-
 		currentMode?.Enabled = false;
 		newMode.Enabled = true;
 

--- a/Code/Weapons/ToolGun/Toolgun.cs
+++ b/Code/Weapons/ToolGun/Toolgun.cs
@@ -92,12 +92,15 @@ public partial class Toolgun : ScreenWeapon
 		if ( newMode == currentMode )
 			return;
 
-		if ( currentMode != null )
+		if ( Network.IsOwner )
 		{
-			currentMode.Enabled = false;
+			currentMode?.SaveCookies();
+			newMode.LoadCookies();
 		}
 
+		currentMode?.Enabled = false;
 		newMode.Enabled = true;
+
 		GameObject.Enabled = true;
 		Network.Refresh( GameObject );
 


### PR DESCRIPTION
Add ICookieSource, which has SaveCookies() and LoadCookies() extension methods. Any [Property] will get saved / loaded from Game.Cookies when those methods are called.

ToolMode extends ICookieSource, and we call SaveCookies / LoadCookies when switching modes, or when closing the tool panel in the spawn menu.

We can re-use ICookieSource for post processing etc later

### Related Issues
* #107 