### PR TITLE
Add explicit namespaces to panels

### DIFF
--- a/Code/Player/Player.cs
+++ b/Code/Player/Player.cs
@@ -1,6 +1,5 @@
 using Sandbox.CameraNoise;
 using Sandbox.Movement;
-using Sandbox.UI.Inventory;
 
 /// <summary>
 /// Holds player information like health

--- a/Code/UI/Chat.razor
+++ b/Code/UI/Chat.razor
@@ -1,6 +1,7 @@
 ﻿@using Sandbox;
 @using Sandbox.UI;
 @using Sandbox.Utility
+@namespace Sandbox
 @inherits PanelComponent
 
 <root>

--- a/Code/UI/Inventory/Inventory.razor
+++ b/Code/UI/Inventory/Inventory.razor
@@ -1,5 +1,6 @@
 ﻿@using Sandbox;
 @using Sandbox.UI;
+@namespace Sandbox
 @inherits PanelComponent
 @implements ILocalPlayerEvent
 

--- a/Code/UI/Inventory/InventorySlot.razor
+++ b/Code/UI/Inventory/InventorySlot.razor
@@ -1,5 +1,6 @@
 ﻿@using Sandbox;
 @using Sandbox.UI;
+@namespace Sandbox
 @inherits Panel
 
 <root>


### PR DESCRIPTION
Some panels / .razor files don't have namespaces set and they default to using the directory structure

That breaks things if those panels get moved (and also adds an extra namespace), this fixes that