### PR TITLE
Toolgun screen marquee scrolling

### DIFF
--- a/Code/Weapons/ToolGun/ToolMode.cs
+++ b/Code/Weapons/ToolGun/ToolMode.cs
@@ -87,7 +87,28 @@ public abstract partial class ToolMode : Component, IToolInfo
 		text.TextColor = Color.Orange;
 		text.FontWeight = 700;
 
-		paint.DrawText( text, rect, TextFlag.Center );
+		var measured = text.Measure();
+	    float textW = measured.x;
+	    float textH = measured.y;
+	
+	    if ( textW <= rect.Width )
+	    {
+	        paint.DrawText( text, rect, TextFlag.Center );
+	        return;
+	    }
+	
+	    // Marquee: scroll text right-to-left, looping seamlessly.
+	    // The render target viewport naturally clips anything outside [0, rect.Width].
+	    const float scrollSpeed = 80f;
+	    const float gap = 60f;
+	    float cycle = textW + gap;
+	    float offset = (Time.Now * scrollSpeed) % cycle;
+	
+	    float y = rect.Top + (rect.Height - textH) * 0.5f;
+	
+	    float x = rect.Width - offset;
+	    paint.DrawText( text, new Rect( x, y, textW, textH ), TextFlag.SingleLine | TextFlag.Left );
+	    paint.DrawText( text, new Rect( x - cycle, y, textW, textH ), TextFlag.SingleLine | TextFlag.Left );
 	}
 
 	public virtual void DrawHud( HudPainter painter, Vector2 crosshair )


### PR DESCRIPTION
The toolgun screen displays the current tool's name, but longer names would get clipped or squished since everything was rendered centered in a fixed rect.

This adds a horizontal marquee (ticker) effect: if the tool name fits within the screen width it renders centered as before, but if it's too wide it smoothly scrolls right-to-left in a seamless infinite loop -- a second copy of the text trails behind so there's no visible reset or snap when the scroll cycles.
<img width="800" height="450" alt="Toolgunscreenmarquee3-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/25e39566-0ff6-4862-b2a8-fac56ea58151" />
