### PR TITLE
Have NPC orient toward look target while navigating; fix nav agent startup race.

### DIFF
--- a/Code/Npcs/Tasks/MoveTo.cs
+++ b/Code/Npcs/Tasks/MoveTo.cs
@@ -5,8 +5,9 @@ namespace Sandbox.Npcs.Tasks;
 /// <summary>
 /// Task that commands the NavigationLayer to move to a target position or GameObject.
 /// When tracking a GameObject, re-evaluates the path periodically.
-/// Does not override the NPC's look target — but will rotate the body to face the
-/// movement direction when the angle would otherwise cause silly walking
+/// If a look target is set (e.g. chasing a player), rotates the body to face that target
+/// each frame. Otherwise, rotates to face the movement direction when the angle would
+/// otherwise cause sideways walking.
 /// </summary>
 public class MoveTo : TaskBase
 {
@@ -61,9 +62,18 @@ public class MoveTo : TaskBase
 			var fwd = Npc.WorldRotation.Forward.WithZ( 0 ).Normal;
 			var angle = Vector3.GetAngle( fwd, moveDir );
 
-			if ( angle > LateralThreshold && !Npc.Animation.LookTarget.HasValue )
+			if ( Npc.Animation.LookTarget.HasValue )
 			{
-				// No look target — face the movement direction
+				// Has a look target (e.g. chasing a player) — rotate body to face the target
+				// directly so the NPC always looks at what it's chasing, not the path direction.
+				var toTarget = (Npc.Animation.LookTarget.Value.WithZ( 0 ) - Npc.WorldPosition.WithZ( 0 )).Normal;
+				var targetRot = Rotation.LookAt( toTarget, Vector3.Up );
+				Npc.GameObject.WorldRotation = Rotation.Lerp(
+					Npc.WorldRotation, targetRot, Npc.Animation.LookSpeed * Time.Delta );
+			}
+			else if ( angle > LateralThreshold )
+			{
+				// No look target — face the movement direction to avoid sideways walking
 				var targetRot = Rotation.LookAt( moveDir, Vector3.Up );
 				Npc.GameObject.WorldRotation = Rotation.Lerp(
 					Npc.WorldRotation, targetRot, Npc.Animation.LookSpeed * Time.Delta );

--- a/code/Npcs/Layers/NavigationLayer.cs
+++ b/code/Npcs/Layers/NavigationLayer.cs
@@ -17,9 +17,18 @@ public class NavigationLayer : BaseNpcLayer
 	/// </summary>
 	public float WishSpeed { get; set; } = 100f;
 
+	// Grace period after issuing a move before we allow failure checks,
+	// so the agent has time to start navigating.
+	private TimeSince _timeSinceLastMoveIssued;
+
 	protected override void OnStart()
 	{
 		Agent = Npc.GetComponent<NavMeshAgent>();
+
+		// We handle rotation ourselves (facing look target or movement direction),
+		// so prevent the agent from snapping the body to the path direction.
+		if ( Agent.IsValid() )
+			Agent.UpdateRotation = false;
 	}
 
 	/// <summary>
@@ -29,6 +38,7 @@ public class NavigationLayer : BaseNpcLayer
 	{
 		MoveTarget = target;
 		StopDistance = stopDistance;
+		_timeSinceLastMoveIssued = 0;
 
 		if ( Agent.IsValid() )
 		{
@@ -49,7 +59,21 @@ public class NavigationLayer : BaseNpcLayer
 		if ( Agent.IsValid() )
 		{
 			Agent.MaxSpeed = WishSpeed;
-			Npc.Animation.SetMove( Agent.Velocity, Agent.WorldRotation );
+			// Use the NPC's actual body rotation (not the agent's path rotation) as the
+			// reference frame so that animation blend parameters (move_x / move_y) are
+			// computed relative to where the body is actually facing.
+			Npc.Animation.SetMove( Agent.Velocity, Npc.WorldRotation );
+
+			// If we have a pending move target but the agent isn't navigating,
+			// and the navmesh just finished building, re-issue the MoveTo so the
+			// agent can register on the freshly-built surface.
+			if ( MoveTarget.HasValue && !Agent.IsNavigating
+				&& !Npc.Scene.NavMesh.IsGenerating && !Npc.Scene.NavMesh.IsDirty
+				&& _timeSinceLastMoveIssued > 0.1f )
+			{
+				Agent.MoveTo( MoveTarget.Value );
+				_timeSinceLastMoveIssued = 0;
+			}
 		}
 	}
 
@@ -75,6 +99,15 @@ public class NavigationLayer : BaseNpcLayer
 
 		if ( distance <= StopDistance )
 			return TaskStatus.Success;
+
+		// If the navmesh is still building (e.g. after procedural geometry was spawned),
+		// keep waiting rather than failing immediately.
+		if ( Npc.Scene.NavMesh.IsGenerating || Npc.Scene.NavMesh.IsDirty )
+			return TaskStatus.Running;
+
+		// Give the agent a short grace period to start navigating after a move is issued.
+		if ( _timeSinceLastMoveIssued < 0.1f )
+			return TaskStatus.Running;
 
 		if ( Agent.IsValid() && !Agent.IsNavigating )
 			return TaskStatus.Failed;


### PR DESCRIPTION
## Summary

Makes NPCs orient their body toward their look target while navigating, so they face what they're chasing rather than the path direction. Also disables the NavMeshAgent's built-in rotation so it no longer fights manual body rotation, and fixes a startup race condition that caused the nav agent to immediately report failure before it had a chance to begin navigating.

## Motivation & Context

Previously, when an NPC was chasing a player (or any look target), the body would only rotate to face the target once the angle exceeded `MaxHeadAngle` (45°). During navigation the NavMeshAgent was also overriding body rotation to match the path direction, causing the NPC to look sideways or away from the player while closing the gap. Additionally, animation blend parameters (`move_x`/`move_y`) were computed relative to the agent's path rotation rather than the body's actual facing direction.

A secondary issue caused the scientist NPC to immediately drop props it had just picked up: the nav agent re-issue logic and the failure check ran in the same frame, so `GetStatus()` saw `!Agent.IsNavigating` before the agent had a chance to start and returned `Failed`, ending the schedule prematurely.

Fixes: <!-- #issue-number (if applicable) -->

## Implementation Details

- **`Code/Npcs/Tasks/MoveTo.cs`** — Body rotation now branches on whether a look target is set. When one is present (e.g. chasing a player), the body rotates to face the look target directly each frame regardless of angle. When no look target is set, the existing lateral-threshold behavior is preserved to avoid sideways walking.
- **`code/Npcs/Layers/NavigationLayer.cs`** — Four changes:
  - `Agent.UpdateRotation = false` on start so the NavMeshAgent no longer overrides manual body rotation.
  - `SetMove` now passes `Npc.WorldRotation` instead of `Agent.WorldRotation` so animation blend parameters are computed relative to where the body is actually facing.
  - Added a re-issue block in `OnUpdate` that re-calls `Agent.MoveTo` if the navmesh finishes building while the agent isn't navigating (handles procedurally generated geometry).
  - Added a `_timeSinceLastMoveIssued` grace period (0.1s) in `GetStatus()` so the agent isn't immediately declared failed before it has had a chance to start navigating after a move is issued.

## Screenshots / Videos (if applicable)
https://github.com/user-attachments/assets/9260189f-a579-4e6f-85b4-4c6f43cb5a07

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I'm okay with this PR being rejected or requested to change 🙂