### PR TITLE
Fix 'Wether' typo in BaseCarryable doc comment

### DIFF
--- a/Code/Game/Weapon/BaseCarryable/BaseCarryable.cs
+++ b/Code/Game/Weapon/BaseCarryable/BaseCarryable.cs
@@ -51,7 +51,7 @@ public partial class BaseCarryable : Component, IKillIcon
 	public virtual string InventoryIconOverride => null;
 
 	/// <summary>
-	/// Wether this weapon should be avoided when determining an item to swap to
+	/// Whether this weapon should be avoided when determining an item to swap to
 	/// </summary>
 	public virtual bool ShouldAvoid => false;
 


### PR DESCRIPTION
One-character fix in the XML doc comment for `BaseCarryable.ShouldAvoid` — `Wether` → `Whether`.