### PR TITLE
Hide face poser on the local player

### DIFF
--- a/Code/UI/FacePoser/FacePoseEditor.razor
+++ b/Code/UI/FacePoser/FacePoseEditor.razor
@@ -64,6 +64,7 @@
         SkinnedModelRenderer smr = null;
         foreach (var go in selection)
         {
+            if ( go.Tags.Has( "player" ) ) continue;
             var found = go.GetComponentInChildren<SkinnedModelRenderer>();
             if (found?.Morphs?.Names?.Length > 0) { smr = found; break; }
         }


### PR DESCRIPTION
Resolves #199

The face poser inspector matches any `SkinnedModelRenderer` with morphs, so it shows up on the local player's own body — which they can't see. Mirrors the existing skip in `Code/UI/Dresser/DresserEditor.razor` that filters out `Tags.Has("player")` for the same reason.

Note: #197 (face poser on the roller) is the same kind of "wrong target" bug but the fix isn't this clean — the roller's `hoverball_morph.vmdl` legitimately has morphs, just not facial ones, and a smart filter would need to distinguish citizen-style face morphs from arbitrary shape morphs. Leaving that for a follow-up.