### PR TITLE
Sort weapons by inventory slot in PlayerInventory

### DIFF
--- a/Code/Player/PlayerInventory.cs
+++ b/Code/Player/PlayerInventory.cs
@@ -9,7 +9,8 @@ public sealed class PlayerInventory : Component, IPlayerEvent, ISaveEvents
 	/// <summary>
 	/// All weapons currently in the inventory, ordered by slot.
 	/// </summary>
-	public IEnumerable<BaseCarryable> Weapons => GetComponentsInChildren<BaseCarryable>( true );
+	public IEnumerable<BaseCarryable> Weapons => 
+		GetComponentsInChildren<BaseCarryable>( true ).OrderBy( x => x.InventorySlot );
 
 	[Sync( SyncFlags.FromHost ), Change] public BaseCarryable ActiveWeapon { get; private set; }
 


### PR DESCRIPTION
Fixes the issue of scrolling between weapons in the hotbar in pickup order rather than by inventory slot order.