### PR TITLE
Change KillSelf damage to maximum float value

### DIFF
--- a/Code/Player/Player.ConsoleCommands.cs
+++ b/Code/Player/Player.ConsoleCommands.cs
@@ -35,7 +35,7 @@ public sealed partial class Player
 	{
 		if ( Rpc.Caller != Network.Owner ) return;
 
-		this.OnDamage( new DamageInfo( 5000, GameObject, null ) );
+		this.OnDamage( new DamageInfo( float.MaxValue, GameObject, null ) );
 	}
 
 	[ConCmd( "god", ConVarFlags.Server | ConVarFlags.Cheat, Help = "Toggle invulnerability" )]


### PR DESCRIPTION
I created a utility for the sandbox that significantly increases player health. This caused an issue where the KillSelf command failed to kill the player because it only dealt 5,000 damage. I’ve updated the damage value to float.MaxValue to make sure the player always dies, no matter how much health they have.