### PR TITLE
Fix health and armor display

### DIFF
--- a/Code/Player/Player.ConsoleCommands.cs
+++ b/Code/Player/Player.ConsoleCommands.cs
@@ -35,7 +35,7 @@ public sealed partial class Player
 	{
 		if ( Rpc.Caller != Network.Owner ) return;
 
-		this.OnDamage( new DamageInfo( 5000, GameObject, null ) );
+		this.OnDamage( new DamageInfo( float.MaxValue, GameObject, null ) );
 	}
 
 	[ConCmd( "god", ConVarFlags.Server | ConVarFlags.Cheat, Help = "Toggle invulnerability" )]

--- a/Code/UI/Vitals/Vitals.razor
+++ b/Code/UI/Vitals/Vitals.razor
@@ -12,12 +12,12 @@
         {
             <div class="stat armour hud-panel">
                 <Image class="icon" Texture=@ArmourIcon />
-                <label class="value">@(ArmourPercent)</label>
+                <label class="value">@(DisplayArmour)</label>
             </div>
         }
         <div class="stat health hud-panel">
             <Image class="icon" Texture=@HealthIcon />
-            <label class="value">@(HealthPercent)</label>
+            <label class="value">@(DisplayHealth)</label>
         </div>
     </div>
 
@@ -43,8 +43,8 @@
     Player Player => Player.FindLocalPlayer();
     BaseWeapon Weapon => Player?.GetComponent<PlayerInventory>()?.ActiveWeapon as BaseWeapon;
 
-    int HealthPercent => (int)(Player.Health / Player.MaxHealth * 100);
-    int ArmourPercent => (int)(Player.Armour / Player.MaxArmour * 100);
+    int DisplayHealth => (int)Player.Health;
+    int DisplayArmour => (int)Player.Armour;
 
     bool IsSpawnMenuOpen()
     {


### PR DESCRIPTION
Fixed a bug where health and armor wouldn't go above 100. Changed calculations from percentages to absolute values so high stats now display correctly
