### PR TITLE
Fix NPC damage condition

### DIFF
--- a/Code/Npcs/Combat/CombatNpc.cs
+++ b/Code/Npcs/Combat/CombatNpc.cs
@@ -106,6 +106,8 @@ public class CombatNpc : Npc, Component.IDamageable
 	{
 		if ( IsProxy )
 			return;
+		if ( Health < 1f )
+			return;
 
 		Health -= damage.Damage;
 

--- a/Code/Npcs/Rollermine/RollermineNpc.cs
+++ b/Code/Npcs/Rollermine/RollermineNpc.cs
@@ -196,6 +196,7 @@ public class RollermineNpc : Npc, Component.IDamageable, Component.ICollisionLis
 	void IDamageable.OnDamage( in DamageInfo damage )
 	{
 		if ( IsProxy ) return;
+		if ( Health <= 0f ) return;
 
 		Health -= damage.Damage;
 

--- a/Code/Npcs/Scientist/ScientistNpc.cs
+++ b/Code/Npcs/Scientist/ScientistNpc.cs
@@ -129,6 +129,8 @@ public class ScientistNpc : Npc, Component.IDamageable
 	{
 		if ( IsProxy )
 			return;
+		if ( Health < 1f )
+			return;
 
 		Health -= damage.Damage;
 


### PR DESCRIPTION
There is a chance that the `OnDamage()` method can be called twice (or more). For example, in the `CombatNpc` component this may cause a  repeat call of `Speech.Say()` and `Die()` methods. So, I added an early return condition if NPC's health is below 1.
The `Player` component is already does this in `OnDamage()` method:
```csharp
public void OnDamage( in DamageInfo dmg )
	{
		if ( Health < 1 ) return;
		if ( !PlayerData.IsValid() ) return;
		if ( PlayerData.IsGodMode ) return;
...
```
I think that `Health` should ideally be a separate component to avoid repetitive code. Like this one, which I've implemented [here](https://github.com/ShadowDash2000/adventuria-sbox/blob/master/Code/Game/Health/Health.cs).