### PR TITLE
Implement NPC Dresser editor with clothing picker

### DIFF
--- a/Code/UI/Dresser/ClothingPickerPopup.razor
+++ b/Code/UI/Dresser/ClothingPickerPopup.razor
@@ -1,0 +1,256 @@
+@using Sandbox;
+@using Sandbox.UI;
+@using System.Collections.Generic;
+@namespace Sandbox
+@inherits BasePopup
+
+<root class="popup">
+
+    <div class="inner" onclick:preventDefault=@true>
+
+        <div class="popup-header">
+            <h2>#spawnmenu.dresser.picker_title</h2>
+        </div>
+        <div class="category-tabs">
+            <div class="cat-tab @( _activeGroup == -1 ? "active" : "" )" @onclick="@(() => SetGroup( -1 ))">#spawnmenu.dresser.tab_all</div>
+            <div class="cat-tab @( _activeGroup == 0 ? "active" : "" )" @onclick="@(() => SetGroup( 0 ))">#spawnmenu.dresser.tab_hats</div>
+            <div class="cat-tab @( _activeGroup == 1 ? "active" : "" )" @onclick="@(() => SetGroup( 1 ))">#spawnmenu.dresser.tab_hair</div>
+            <div class="cat-tab @( _activeGroup == 2 ? "active" : "" )" @onclick="@(() => SetGroup( 2 ))">#spawnmenu.dresser.tab_tops</div>
+            <div class="cat-tab @( _activeGroup == 3 ? "active" : "" )" @onclick="@(() => SetGroup( 3 ))">#spawnmenu.dresser.tab_bottoms</div>
+            <div class="cat-tab @( _activeGroup == 4 ? "active" : "" )" @onclick="@(() => SetGroup( 4 ))">#spawnmenu.dresser.tab_footwear</div>
+            <div class="cat-tab @( _activeGroup == 5 ? "active" : "" )" @onclick="@(() => SetGroup( 5 ))">#spawnmenu.dresser.tab_accessories</div>
+            <div class="cat-tab @( _activeGroup == 6 ? "active" : "" )" @onclick="@(() => SetGroup( 6 ))">#spawnmenu.dresser.tab_outfits</div>
+        </div>
+
+        <VirtualGrid Items=@_filteredItems ItemSize=@(new Vector2( 180, 200 )) class="clothing-grid">
+            <Item Context="item">
+                @if ( item is Clothing clothing )
+                {
+                    bool selected = _selectedPaths.Contains( clothing.ResourcePath );
+                    string itemClass = selected ? "clothing-item active" : "clothing-item";
+                    string thumbUrl = $"thumb:{clothing.ResourcePath}";
+
+                    <div class="@itemClass" @onclick="@(() => ToggleItem( clothing ))">
+                        <div class="clothing-icon" style="background-image: url(@thumbUrl)"></div>
+                        <div class="clothing-title">@clothing.Title</div>
+                        @if ( selected )
+                        {
+                            <div class="check-badge">✓</div>
+                        }
+                    </div>
+                }
+            </Item>
+        </VirtualGrid>
+
+        <div class="popup-footer">
+            <div class="selection-count">@GetSelectionLabel()</div>
+            <div class="cancel-button" @onclick=@Close>#spawnmenu.dresser.cancel</div>
+            <div class="select-button @( _selectedPaths.Count == 0 ? "disabled" : "" )" @onclick=@ConfirmSelection>@GetEquipLabel()</div>
+        </div>
+
+    </div>
+
+</root>
+
+@code
+{
+    public Action<List<string>> OnSelectedFiles;
+
+    HashSet<string> _selectedPaths = new HashSet<string>();
+    int _activeGroup = -1;
+    List<object> _filteredItems = new List<object>();
+
+    // Static cache so we only scan ResourceLibrary once across all popup opens
+    static List<Clothing> _cachedAllItems;
+    static bool _cacheBuilt;
+
+    static void EnsureCache()
+    {
+        if ( _cacheBuilt ) return;
+
+        _cachedAllItems = new List<Clothing>();
+
+        foreach ( var c in ResourceLibrary.GetAll<Clothing>() )
+        {
+            // Only citizen/terry compatible: must have a Model path and not be a human skin
+            if ( string.IsNullOrEmpty( c.Model ) ) continue;
+            if ( c.HasHumanSkin ) continue;
+            _cachedAllItems.Add( c );
+        }
+        _cachedAllItems.Sort( ( a, b ) => string.Compare( a.Title, b.Title, System.StringComparison.Ordinal ) );
+
+        _cacheBuilt = true;
+    }
+
+    protected override void OnAfterTreeRender( bool firstTime )
+    {
+        if ( !firstTime ) return;
+
+        EnsureCache();
+        RebuildFiltered();
+        StateHasChanged();
+    }
+
+    void SetGroup( int group )
+    {
+        _activeGroup = group;
+        RebuildFiltered();
+        StateHasChanged();
+    }
+
+    void RebuildFiltered()
+    {
+        _filteredItems = new List<object>();
+
+        if ( _cachedAllItems == null ) return;
+
+        foreach ( var item in _cachedAllItems )
+        {
+            if ( _activeGroup >= 0 && GetGroup( item.Category ) != _activeGroup )
+                continue;
+
+            _filteredItems.Add( item );
+        }
+    }
+
+    void ToggleItem( Clothing clothing )
+    {
+        if ( _selectedPaths.Contains( clothing.ResourcePath ) )
+            _selectedPaths.Remove( clothing.ResourcePath );
+        else
+            _selectedPaths.Add( clothing.ResourcePath );
+
+        StateHasChanged();
+    }
+
+    string GetSelectionLabel()
+    {
+        if ( _selectedPaths.Count == 0 ) return "";
+        if ( _selectedPaths.Count == 1 ) return Game.Language.GetPhrase( "spawnmenu.dresser.items_selected_one" );
+        return Game.Language.GetPhrase( "spawnmenu.dresser.items_selected" ).Replace( "{count}", _selectedPaths.Count.ToString() );
+    }
+
+    string GetEquipLabel()
+    {
+        var label = Game.Language.GetPhrase( "spawnmenu.dresser.equip" );
+        if ( _selectedPaths.Count > 0 )
+            return $"{label} ({_selectedPaths.Count})";
+        return label;
+    }
+
+    void ConfirmSelection()
+    {
+        if ( _selectedPaths.Count == 0 ) return;
+
+        var paths = new List<string>();
+        foreach ( var path in _selectedPaths )
+            paths.Add( path );
+
+        OnSelectedFiles?.Invoke( paths );
+        Delete();
+    }
+
+    void Close()
+    {
+        Delete();
+    }
+
+    protected override void OnMouseDown( MousePanelEvent e )
+    {
+        base.OnMouseDown( e );
+        if ( e.Target == this )
+            Delete();
+    }
+
+    /// <summary>
+    /// Maps individual ClothingCategory values into broad groups for the tab filter.
+    /// 0=Hats, 1=Hair, 2=Tops, 3=Bottoms, 4=Footwear, 5=Accessories, 6=Outfits
+    /// </summary>
+    static int GetGroup( Clothing.ClothingCategory category )
+    {
+        var key = (int)category;
+
+        // Hats & Headwear
+        if ( key == (int)Clothing.ClothingCategory.Hat ) return 0;
+        if ( key == (int)Clothing.ClothingCategory.HatCap ) return 0;
+        if ( key == (int)Clothing.ClothingCategory.HatBeanie ) return 0;
+        if ( key == (int)Clothing.ClothingCategory.HatFormal ) return 0;
+        if ( key == (int)Clothing.ClothingCategory.HatCostume ) return 0;
+        if ( key == (int)Clothing.ClothingCategory.HatUniform ) return 0;
+        if ( key == (int)Clothing.ClothingCategory.HatSpecial ) return 0;
+        if ( key == (int)Clothing.ClothingCategory.Headwear ) return 0;
+
+        // Hair & Facial
+        if ( key == (int)Clothing.ClothingCategory.Hair ) return 1;
+        if ( key == (int)Clothing.ClothingCategory.HairShort ) return 1;
+        if ( key == (int)Clothing.ClothingCategory.HairMedium ) return 1;
+        if ( key == (int)Clothing.ClothingCategory.HairLong ) return 1;
+        if ( key == (int)Clothing.ClothingCategory.HairUpdo ) return 1;
+        if ( key == (int)Clothing.ClothingCategory.HairSpecial ) return 1;
+        if ( key == (int)Clothing.ClothingCategory.Facial ) return 1;
+        if ( key == (int)Clothing.ClothingCategory.FacialHairMustache ) return 1;
+        if ( key == (int)Clothing.ClothingCategory.FacialHairBeard ) return 1;
+        if ( key == (int)Clothing.ClothingCategory.FacialHairStubble ) return 1;
+        if ( key == (int)Clothing.ClothingCategory.FacialHairSideburns ) return 1;
+        if ( key == (int)Clothing.ClothingCategory.FacialHairGoatee ) return 1;
+        if ( key == (int)Clothing.ClothingCategory.Eyebrows ) return 1;
+
+        // Tops
+        if ( key == (int)Clothing.ClothingCategory.Tops ) return 2;
+        if ( key == (int)Clothing.ClothingCategory.TShirt ) return 2;
+        if ( key == (int)Clothing.ClothingCategory.Shirt ) return 2;
+        if ( key == (int)Clothing.ClothingCategory.Sweatshirt ) return 2;
+        if ( key == (int)Clothing.ClothingCategory.Hoodie ) return 2;
+        if ( key == (int)Clothing.ClothingCategory.Jacket ) return 2;
+        if ( key == (int)Clothing.ClothingCategory.Coat ) return 2;
+        if ( key == (int)Clothing.ClothingCategory.Vest ) return 2;
+        if ( key == (int)Clothing.ClothingCategory.Knitwear ) return 2;
+        if ( key == (int)Clothing.ClothingCategory.Cardigan ) return 2;
+        if ( key == (int)Clothing.ClothingCategory.Gilet ) return 2;
+
+        // Bottoms
+        if ( key == (int)Clothing.ClothingCategory.Bottoms ) return 3;
+        if ( key == (int)Clothing.ClothingCategory.Trousers ) return 3;
+        if ( key == (int)Clothing.ClothingCategory.Jeans ) return 3;
+        if ( key == (int)Clothing.ClothingCategory.Shorts ) return 3;
+        if ( key == (int)Clothing.ClothingCategory.Skirt ) return 3;
+
+        // Footwear
+        if ( key == (int)Clothing.ClothingCategory.Footwear ) return 4;
+        if ( key == (int)Clothing.ClothingCategory.Shoes ) return 4;
+        if ( key == (int)Clothing.ClothingCategory.Boots ) return 4;
+        if ( key == (int)Clothing.ClothingCategory.Trainers ) return 4;
+        if ( key == (int)Clothing.ClothingCategory.Heels ) return 4;
+        if ( key == (int)Clothing.ClothingCategory.Sandals ) return 4;
+        if ( key == (int)Clothing.ClothingCategory.Slippers ) return 4;
+        if ( key == (int)Clothing.ClothingCategory.Socks ) return 4;
+
+        // Accessories
+        if ( key == (int)Clothing.ClothingCategory.Gloves ) return 5;
+        if ( key == (int)Clothing.ClothingCategory.Eyewear ) return 5;
+        if ( key == (int)Clothing.ClothingCategory.GlassesEye ) return 5;
+        if ( key == (int)Clothing.ClothingCategory.GlassesSun ) return 5;
+        if ( key == (int)Clothing.ClothingCategory.GlassesSpecial ) return 5;
+        if ( key == (int)Clothing.ClothingCategory.NecklaceChain ) return 5;
+        if ( key == (int)Clothing.ClothingCategory.NecklacePendant ) return 5;
+        if ( key == (int)Clothing.ClothingCategory.NecklaceSpecial ) return 5;
+        if ( key == (int)Clothing.ClothingCategory.EarringStud ) return 5;
+        if ( key == (int)Clothing.ClothingCategory.EarringDangle ) return 5;
+        if ( key == (int)Clothing.ClothingCategory.EarringSpecial ) return 5;
+        if ( key == (int)Clothing.ClothingCategory.Wristwear ) return 5;
+        if ( key == (int)Clothing.ClothingCategory.WristWatch ) return 5;
+        if ( key == (int)Clothing.ClothingCategory.WristBand ) return 5;
+        if ( key == (int)Clothing.ClothingCategory.Ring ) return 5;
+        if ( key == (int)Clothing.ClothingCategory.Piercing ) return 5;
+
+        // Outfits (full body / costumes / uniforms)
+        if ( key == (int)Clothing.ClothingCategory.Fullbody ) return 6;
+        if ( key == (int)Clothing.ClothingCategory.Costume ) return 6;
+        if ( key == (int)Clothing.ClothingCategory.Uniform ) return 6;
+        if ( key == (int)Clothing.ClothingCategory.Dress ) return 6;
+        if ( key == (int)Clothing.ClothingCategory.Suit ) return 6;
+        if ( key == (int)Clothing.ClothingCategory.Skin ) return 6;
+
+        return 5; // default to accessories
+    }
+}

--- a/Code/UI/Dresser/ClothingPickerPopup.razor.scss
+++ b/Code/UI/Dresser/ClothingPickerPopup.razor.scss
@@ -1,0 +1,190 @@
+@import "/UI/Popup.scss";
+
+ClothingPickerPopup .inner
+{
+    width: 900px;
+    height: 850px;
+
+    .popup-header
+    {
+        flex-shrink: 0;
+        padding-bottom: 8px;
+
+        h2
+        {
+            font-size: 2rem;
+        }
+    }
+
+    .category-tabs
+    {
+        flex-direction: row;
+        gap: 4px;
+        flex-shrink: 0;
+        padding-bottom: 12px;
+
+        .cat-tab
+        {
+            font-size: 1.3rem;
+            padding: 0.5rem 1.2rem;
+            color: rgba( white, 0.6 );
+            background-color: rgba( white, 0.08 );
+            cursor: pointer;
+            border-radius: 5px;
+            pointer-events: all;
+
+            &:hover
+            {
+                color: white;
+                background-color: rgba( white, 0.16 );
+            }
+
+            &.active
+            {
+                color: white;
+                background-color: #08f5;
+            }
+        }
+    }
+
+    .clothing-grid
+    {
+        width: 100%;
+        flex-grow: 1;
+        gap: 1rem;
+        background-color: #1a1a1acc;
+        padding: 1rem;
+        border-radius: 10px;
+    }
+
+    .clothing-grid .clothing-item
+    {
+        width: 100%;
+        height: 100%;
+        color: #aaa;
+        pointer-events: all;
+        border-radius: 10px;
+        margin: 0.25rem;
+        cursor: pointer;
+        position: relative;
+        flex-direction: column;
+        padding: 1rem;
+        font-size: 1rem;
+        align-items: center;
+        justify-content: center;
+
+        .clothing-icon
+        {
+            height: 110px;
+            width: 110px;
+            overflow: hidden;
+            justify-content: center;
+            align-items: center;
+            flex-shrink: 0;
+            background-position: center;
+            background-size: contain;
+            background-repeat: no-repeat;
+        }
+
+        .clothing-title
+        {
+            font-weight: 600;
+            font-size: 1.3rem;
+            color: rgba( white, 0.9 );
+            flex-shrink: 0;
+            text-align: center;
+            text-overflow: ellipsis;
+            overflow: hidden;
+            white-space: nowrap;
+            width: 100%;
+            padding-top: 0.5rem;
+        }
+
+        .check-badge
+        {
+            position: absolute;
+            top: 6px;
+            right: 6px;
+            width: 22px;
+            height: 22px;
+            background-color: #08f;
+            border-radius: 50%;
+            color: white;
+            font-size: 1.2rem;
+            font-weight: 700;
+            justify-content: center;
+            align-items: center;
+        }
+
+        &:hover
+        {
+            background-color: rgba( #08f, 0.3 );
+        }
+
+        &.active
+        {
+            background-color: rgba( #08f, 0.2 );
+            outline: 2px solid #08f;
+            outline-offset: -2px;
+        }
+    }
+
+    .popup-footer
+    {
+        flex-direction: row;
+        justify-content: flex-end;
+        align-items: center;
+        padding: 0.8rem 0;
+        flex-shrink: 0;
+        gap: 0.8rem;
+
+        .selection-count
+        {
+            flex-grow: 1;
+            font-size: 1.2rem;
+            color: rgba( white, 0.5 );
+        }
+
+        .cancel-button
+        {
+            padding: 0.7rem 2.5rem;
+            background-color: rgba( white, 0.1 );
+            color: rgba( white, 0.7 );
+            font-weight: 700;
+            font-size: 1.3rem;
+            border-radius: 6px;
+            cursor: pointer;
+            pointer-events: all;
+
+            &:hover
+            {
+                background-color: rgba( white, 0.2 );
+                color: white;
+            }
+        }
+
+        .select-button
+        {
+            padding: 0.7rem 2.5rem;
+            background-color: #08f;
+            color: white;
+            font-weight: 700;
+            font-size: 1.3rem;
+            border-radius: 6px;
+            cursor: pointer;
+            pointer-events: all;
+
+            &:hover
+            {
+                background-color: #09f;
+            }
+
+            &.disabled
+            {
+                background-color: rgba( white, 0.05 );
+                color: rgba( white, 0.3 );
+                cursor: default;
+            }
+        }
+    }
+}

--- a/Code/UI/Dresser/DresserEditor.razor
+++ b/Code/UI/Dresser/DresserEditor.razor
@@ -1,5 +1,6 @@
 @using Sandbox;
 @using Sandbox.UI;
+@using System.Collections.Generic;
 @attribute [InspectorEditor(typeof(Dresser))]
 @inherits Panel
 @namespace Sandbox
@@ -7,11 +8,36 @@
 
 <root>
     <div class="body">
-        <Label>todo: add / remove clothing resources</Label>
+        @if ( Target.IsValid() && Target.Clothing.Count > 0 )
+        {
+            @foreach ( var group in GetClothingGrouped() )
+            {
+                <div class="category-header">@GetCategoryLabel( group.Key )</div>
+
+                @foreach ( var entry in group.Value )
+                {
+                    var captured = entry;
+                    var clothing = entry.Clothing;
+                    var title = clothing != null ? clothing.Title : "Unknown";
+                    var thumbUrl = clothing != null ? $"thumb:{clothing.ResourcePath}" : "";
+
+                    <div class="clothing-row">
+                        <div class="clothing-thumb" style="background-image: url(@thumbUrl)"></div>
+                        <div class="clothing-name">@title</div>
+                        <div class="clothing-remove" @onclick="@(() => RemoveClothing( captured ))">✕</div>
+                    </div>
+                }
+            }
+        }
+        else
+        {
+            <div class="empty-state">#spawnmenu.dresser.no_items</div>
+        }
     </div>
     <div class="footer">
-            <Button class="menu-action primary" Text="Randomize" Icon="🎲" onclick=@DoRandomize></Button>
-            <Button class="menu-action primary" Text="Clear" Icon="🧹" onclick=@DoClear></Button>
+            <Button class="menu-action primary" Text="#spawnmenu.dresser.add" Icon="➕" onclick=@DoAdd></Button>
+            <Button class="menu-action primary" Text="#spawnmenu.dresser.randomize" Icon="🎲" onclick=@DoRandomize></Button>
+            <Button class="menu-action primary" Text="#spawnmenu.dresser.clear" Icon="🧹" onclick=@DoClear></Button>
     </div>
 </root>
 
@@ -38,8 +64,162 @@
         return Target != null;
     }
 
+    struct ClothingGroup
+    {
+        public Clothing.ClothingCategory Key;
+        public List<ClothingContainer.ClothingEntry> Value;
+    }
+
+    /// <summary>
+    /// Groups the current clothing list by category for display.
+    /// </summary>
+    List<ClothingGroup> GetClothingGrouped()
+    {
+        var groups = new Dictionary<Clothing.ClothingCategory, List<ClothingContainer.ClothingEntry>>();
+
+        foreach ( var entry in Target.Clothing )
+        {
+            if ( entry.Clothing == null ) continue;
+
+            var cat = entry.Clothing.Category;
+            if ( !groups.ContainsKey( cat ) )
+                groups[cat] = new List<ClothingContainer.ClothingEntry>();
+
+            groups[cat].Add( entry );
+        }
+
+        var result = new List<ClothingGroup>();
+        foreach ( var kvp in groups )
+        {
+            result.Add( new ClothingGroup { Key = kvp.Key, Value = kvp.Value } );
+        }
+        result.Sort( ( a, b ) => ((int)a.Key).CompareTo( (int)b.Key ) );
+        return result;
+    }
+
+    static string GetCategoryLabel( Clothing.ClothingCategory category )
+    {
+        var key = (int)category;
+
+        if ( key == (int)Clothing.ClothingCategory.Hat ) return "Hats";
+        if ( key == (int)Clothing.ClothingCategory.HatCap ) return "Caps";
+        if ( key == (int)Clothing.ClothingCategory.HatBeanie ) return "Beanies";
+        if ( key == (int)Clothing.ClothingCategory.HatFormal ) return "Formal Hats";
+        if ( key == (int)Clothing.ClothingCategory.HatCostume ) return "Costume Hats";
+        if ( key == (int)Clothing.ClothingCategory.HatUniform ) return "Uniform Hats";
+        if ( key == (int)Clothing.ClothingCategory.Hair ) return "Hair";
+        if ( key == (int)Clothing.ClothingCategory.HairShort ) return "Short Hair";
+        if ( key == (int)Clothing.ClothingCategory.HairMedium ) return "Medium Hair";
+        if ( key == (int)Clothing.ClothingCategory.HairLong ) return "Long Hair";
+        if ( key == (int)Clothing.ClothingCategory.Facial ) return "Facial Hair";
+        if ( key == (int)Clothing.ClothingCategory.Eyewear ) return "Eyewear";
+        if ( key == (int)Clothing.ClothingCategory.Tops ) return "Tops";
+        if ( key == (int)Clothing.ClothingCategory.TShirt ) return "T-Shirts";
+        if ( key == (int)Clothing.ClothingCategory.Shirt ) return "Shirts";
+        if ( key == (int)Clothing.ClothingCategory.Hoodie ) return "Hoodies";
+        if ( key == (int)Clothing.ClothingCategory.Jacket ) return "Jackets";
+        if ( key == (int)Clothing.ClothingCategory.Coat ) return "Coats";
+        if ( key == (int)Clothing.ClothingCategory.Vest ) return "Vests";
+        if ( key == (int)Clothing.ClothingCategory.Bottoms ) return "Bottoms";
+        if ( key == (int)Clothing.ClothingCategory.Trousers ) return "Trousers";
+        if ( key == (int)Clothing.ClothingCategory.Jeans ) return "Jeans";
+        if ( key == (int)Clothing.ClothingCategory.Shorts ) return "Shorts";
+        if ( key == (int)Clothing.ClothingCategory.Skirt ) return "Skirts";
+        if ( key == (int)Clothing.ClothingCategory.Footwear ) return "Footwear";
+        if ( key == (int)Clothing.ClothingCategory.Shoes ) return "Shoes";
+        if ( key == (int)Clothing.ClothingCategory.Boots ) return "Boots";
+        if ( key == (int)Clothing.ClothingCategory.Trainers ) return "Trainers";
+        if ( key == (int)Clothing.ClothingCategory.Gloves ) return "Gloves";
+        if ( key == (int)Clothing.ClothingCategory.Skin ) return "Skin";
+        if ( key == (int)Clothing.ClothingCategory.Fullbody ) return "Full Body";
+        if ( key == (int)Clothing.ClothingCategory.Costume ) return "Costumes";
+        if ( key == (int)Clothing.ClothingCategory.Uniform ) return "Uniforms";
+
+        return category.ToString();
+    }
+
+    void DoAdd()
+    {
+        if ( !Target.IsValid() ) return;
+
+        var popup = new ClothingPickerPopup();
+        popup.Parent = FindPopupPanel();
+        popup.OnSelectedFiles = ( paths ) =>
+        {
+            if ( paths == null || paths.Count == 0 ) return;
+            TryBroadcastAddMultiple( Target.GameObject, paths );
+        };
+    }
+
+    void RemoveClothing( ClothingContainer.ClothingEntry entry )
+    {
+        if ( !Target.IsValid() || entry.Clothing == null ) return;
+        TryBroadcastRemove( Target.GameObject, entry.Clothing.ResourcePath );
+    }
+
     void DoRandomize() => TryBroadcastRandomize( Target.GameObject );
     void DoClear() => TryBroadcastClear( Target.GameObject );
+
+    [Rpc.Host]
+    private static async void TryBroadcastAddMultiple( GameObject go, List<string> clothingPaths )
+    {
+        if ( !go.IsValid() ) return;
+
+        var dresser = go.GetComponentInChildren<Dresser>();
+        if ( dresser is null ) return;
+
+        // Build a set of already-equipped paths to prevent duplicates
+        var equipped = new HashSet<string>();
+        foreach ( var existing in dresser.Clothing )
+        {
+            if ( existing.Clothing != null )
+                equipped.Add( existing.Clothing.ResourcePath );
+        }
+
+        foreach ( var path in clothingPaths )
+        {
+            // Skip if already equipped
+            if ( equipped.Contains( path ) ) continue;
+
+            var clothing = ResourceLibrary.Get<Clothing>( path );
+            if ( clothing is null ) continue;
+
+            // Only allow citizen-compatible clothing (has a Model for the citizen body)
+            if ( string.IsNullOrEmpty( clothing.Model ) ) continue;
+
+            dresser.Clothing.Add( new ClothingContainer.ClothingEntry( clothing ) );
+            equipped.Add( path );
+        }
+
+        await dresser.Apply();
+        go.Network.Refresh();
+    }
+
+    [Rpc.Host]
+    private static async void TryBroadcastRemove( GameObject go, string clothingPath )
+    {
+        if ( !go.IsValid() ) return;
+
+        var dresser = go.GetComponentInChildren<Dresser>();
+        if ( dresser is null ) return;
+
+        ClothingContainer.ClothingEntry found = null;
+        foreach ( var e in dresser.Clothing )
+        {
+            if ( e.Clothing != null && e.Clothing.ResourcePath == clothingPath )
+            {
+                found = e;
+                break;
+            }
+        }
+        if ( found is null ) return;
+
+        dresser.Clothing.Remove( found );
+        dresser.Clear();
+        await dresser.Apply();
+
+        go.Network.Refresh();
+    }
 
     [Rpc.Host]
     private static void TryBroadcastRandomize(GameObject go)
@@ -51,7 +231,6 @@
 
         dresser.Randomize();
 
-        // Refresh the object to update the clothing items for everyone
         go.Network.Refresh();
     }
 
@@ -67,7 +246,9 @@
         dresser.Clear();
         await dresser.Apply();
 
-        // Refresh the object to update the clothing items for everyone
         go.Network.Refresh();
     }
+
+    protected override int BuildHash() =>
+        HashCode.Combine( Target?.Clothing?.Count ?? 0 );
 }

--- a/Code/UI/Dresser/DresserEditor.razor.scss
+++ b/Code/UI/Dresser/DresserEditor.razor.scss
@@ -5,4 +5,70 @@ DresserEditor
     flex-direction: column;
     width: 100%;
     justify-content: flex-end;
+
+    .category-header
+    {
+        padding: 6px 8px 2px;
+        font-size: 11px;
+        font-weight: 600;
+        color: rgba(white, 0.5);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+    }
+
+    .clothing-row
+    {
+        flex-direction: row;
+        align-items: center;
+        padding: 4px 8px;
+        gap: 8px;
+        border-bottom: 1px solid rgba(white, 0.05);
+
+        &:hover
+        {
+            background-color: rgba(white, 0.05);
+        }
+
+        .clothing-thumb
+        {
+            width: 32px;
+            height: 32px;
+            background-size: cover;
+            background-position: center;
+            border-radius: 4px;
+            flex-shrink: 0;
+        }
+
+        .clothing-name
+        {
+            flex-grow: 1;
+            font-size: 12px;
+            color: rgba(white, 0.8);
+            text-overflow: ellipsis;
+            overflow: hidden;
+            white-space: nowrap;
+        }
+
+        .clothing-remove
+        {
+            flex-shrink: 0;
+            font-size: 12px;
+            color: rgba(white, 0.4);
+            cursor: pointer;
+            padding: 4px;
+
+            &:hover
+            {
+                color: rgba(#ff4444, 1);
+            }
+        }
+    }
+
+    .empty-state
+    {
+        padding: 12px;
+        text-align: center;
+        font-size: 12px;
+        color: rgba(white, 0.4);
+    }
 }

--- a/Localization/en/menu.json
+++ b/Localization/en/menu.json
@@ -149,5 +149,24 @@
     "spawnmenu.common.load": "Load",
     "spawnmenu.common.items": "items",
 
-    "spawnmenu.mounts.error": "Error getting mount."
+    "spawnmenu.mounts.error": "Error getting mount.",
+
+    "spawnmenu.dresser.title": "Dresser",
+    "spawnmenu.dresser.add": "Add",
+    "spawnmenu.dresser.randomize": "Randomize",
+    "spawnmenu.dresser.clear": "Clear",
+    "spawnmenu.dresser.no_items": "No clothing items",
+    "spawnmenu.dresser.picker_title": "Select Clothing (Citizen)",
+    "spawnmenu.dresser.tab_all": "All",
+    "spawnmenu.dresser.tab_hats": "Hats",
+    "spawnmenu.dresser.tab_hair": "Hair",
+    "spawnmenu.dresser.tab_tops": "Tops",
+    "spawnmenu.dresser.tab_bottoms": "Bottoms",
+    "spawnmenu.dresser.tab_footwear": "Footwear",
+    "spawnmenu.dresser.tab_accessories": "Accessories",
+    "spawnmenu.dresser.tab_outfits": "Outfits",
+    "spawnmenu.dresser.cancel": "Cancel",
+    "spawnmenu.dresser.equip": "Equip",
+    "spawnmenu.dresser.items_selected_one": "1 item selected",
+    "spawnmenu.dresser.items_selected": "{count} items selected"
 }


### PR DESCRIPTION
# Implement NPC Dresser Editor

Hooks up the TODO in `DresserEditor.razor` - you can now add/remove clothing on NPCs through the inspector.

## Changes

- **DresserEditor** - Shows equipped clothing grouped by category. Add, remove, randomise, and clear buttons.
- **ClothingPickerPopup** - New popup for picking clothing. Filtered to citizen model only (no human skins). Has category tabs and multi-select so you can equip a full outfit in one go.
- **Localisation** - Added English keys for all new UI strings (`spawnmenu.dresser.*`).

## Notes

- Only shows clothing that has a `Model` set and isn't a human skin - keeps the picker relevant for terry/citizen NPCs
- Can't equip the same item twice
- All changes go through `[Rpc.Host]` so it works in multiplayer

## To test

1. Spawn a scientist or army guy
2. Hold C, click the NPC and go to the Dresser tab
3. Try adding clothing, removing items, randomising, and clearing
4. Check that duplicates get rejected

## Video

https://github.com/user-attachments/assets/b52e1136-e85a-4d07-af73-83b06b10c845
