### PR TITLE
First-person: improvements while in noclip state

### DIFF
--- a/Code/Game/Weapon/WeaponModel/ViewModel.cs
+++ b/Code/Game/Weapon/WeaponModel/ViewModel.cs
@@ -93,6 +93,9 @@ public sealed partial class ViewModel : WeaponModel, ICameraSetup
 	float bobCycleControl;
 	TimeSince bobCycleMoving;
 
+	// Noclip positional offset (lowered weapon)
+	float noclipOffset;
+
 	protected override void OnStart()
 	{
 		foreach ( var renderer in GetComponentsInChildren<ModelRenderer>() )
@@ -136,7 +139,33 @@ public sealed partial class ViewModel : WeaponModel, ICameraSetup
 		WorldRotation = cc.WorldRotation;
 
 		ApplyInertia();
+		ApplyNoclipOffset();
 		ApplyAnimationTransform( cc );
+	}
+
+	void ApplyNoclipOffset()
+	{
+		var player = GetComponentInParent<Player>();
+		var weapon = GetComponentInParent<IronSightsWeapon>();
+		var isAiming = weapon.IsValid() && weapon.IsAiming;
+		var wantsOffset = player.IsValid() && player.IsNoclipping && !isAiming;
+
+		var speed = isAiming ? 15f : 4f; // Fast transition if going into ironsights, slower otherwise.
+		noclipOffset = noclipOffset.LerpTo( wantsOffset ? 1f : 0f, Time.Delta * speed );
+
+		if ( noclipOffset > 0.001f )
+		{
+			var t = Time.Now * 0.3f;
+			var sway = new Vector3(
+				MathF.Sin( t * MathF.Tau ) * 0.15f,
+				MathF.Sin( t * MathF.Tau + 2f ) * 0.1f,
+				MathF.Sin( t * MathF.Tau + 4f ) * 0.1f
+			);
+
+			WorldPosition += WorldRotation.Down * noclipOffset * 1.6f;
+			WorldPosition += WorldRotation.Backward * noclipOffset * 0.9f;
+			WorldPosition += (WorldRotation.Right * sway.x + WorldRotation.Up * sway.y + WorldRotation.Forward * sway.z) * noclipOffset;
+		}
 	}
 
 	void ApplyAnimationTransform( CameraComponent cc )

--- a/Code/Game/Weapon/WeaponModel/ViewModel.cs
+++ b/Code/Game/Weapon/WeaponModel/ViewModel.cs
@@ -89,6 +89,10 @@ public sealed partial class ViewModel : WeaponModel, ICameraSetup
 	Vector2 currentInertia;
 	bool isFirstUpdate = true;
 
+	// Move bob cycle control: manually scrub the bob cycle (e.g. while noclipping), then wind down smoothly on exit
+	float bobCycleControl;
+	TimeSince bobCycleMoving;
+
 	protected override void OnStart()
 	{
 		foreach ( var renderer in GetComponentsInChildren<ModelRenderer>() )
@@ -158,8 +162,10 @@ public sealed partial class ViewModel : WeaponModel, ICameraSetup
 		Renderer.Set( "deploy_type", UseFastAnimations ? 1 : 0 );
 		Renderer.Set( "reload_type", UseFastAnimations ? 1 : 0 );
 
-		Renderer.Set( "b_grounded", playerController.IsOnGround );
-		Renderer.Set( "move_bob", GamePreferences.ViewBobbing ? playerController.Velocity.Length.Remap( 0, playerController.RunSpeed * 2f ) : 0 );
+		var player = GetComponentInParent<Player>();
+
+		var isNoclipping = player.IsValid() && player.IsNoclipping;		// Treat noclip as grounded so the viewmodel doesn't play falling anims
+		Renderer.Set( "b_grounded", playerController.IsOnGround || isNoclipping );
 
 		Renderer.Set( "aim_pitch", rot.pitch );
 		Renderer.Set( "aim_pitch_inertia", currentInertia.x * InertiaScale.x );
@@ -184,6 +190,35 @@ public sealed partial class ViewModel : WeaponModel, ICameraSetup
 
 		var angle = MathF.Atan2( sideward, forward ).RadianToDegree().NormalizeDegrees();
 
+		var bobIntensity = GamePreferences.ViewBobbing ? velocity.Length.Remap( 0, playerController.RunSpeed * 2f ) : 0;
+		Renderer.Set( "move_bob", bobIntensity );
+
+		// While noclipping, take over bob cycle and scrub slowly (3s/loop).
+		// On exit, wind down to 0 via shortest path so there's no pop.
+		var wantsNoclipBob = isNoclipping && bobIntensity > 0f;
+
+		if ( wantsNoclipBob )
+		{
+			// Wait 100ms before taking over cycle control
+			if ( bobCycleMoving > 0.1f )
+				bobCycleControl = (bobCycleControl + Time.Delta / 3f) % 1f;
+		}
+		else
+		{
+			bobCycleMoving = 0f;
+			// Smoothly wind down to 0 via shortest path
+			if ( bobCycleControl != 0f )
+			{
+				var step = Time.Delta * 2f;
+
+				if ( bobCycleControl <= 0.5f )
+					bobCycleControl = MathF.Max( 0f, bobCycleControl - step );
+				else
+					bobCycleControl = (bobCycleControl + step) >= 1f ? 0f : bobCycleControl + step;
+			}
+		}
+
+		Renderer.Set( "move_bob_cycle_control", bobCycleControl );
 		Renderer.Set( "move_direction", angle );
 		Renderer.Set( "move_speed", velocity.Length );
 		Renderer.Set( "move_groundspeed", velocity.WithZ( 0 ).Length );


### PR DESCRIPTION
This fixes noclip looking weird in first-person

- Noclipping now counts as "grounded" so the viewmodel doesn't play falling/airborne anims while flying around.
- Move bob cycle is manually scrubbed at a slow steady rate while noclipping
- On exiting noclip, the bob cycle smoothly winds back down to 0 so there's no pop.
- Positional offset that gets subtly animated while in noclip state, gets removed much faster if aiming down sights

https://github.com/user-attachments/assets/e873efdd-9a14-4831-aad0-49212b75ae49

https://github.com/user-attachments/assets/a3cd9b8a-1a21-4f81-88b0-160bd47d4799


