### PR TITLE
(FOR ENGINE PR) BaseCarryable: set DamageInfo.Force so gibs scatter correctly on prop break

### DIFF
--- a/Code/Game/Weapon/BaseCarryable/BaseCarryable.cs
+++ b/Code/Game/Weapon/BaseCarryable/BaseCarryable.cs
@@ -324,12 +324,7 @@ public partial class BaseCarryable : Component, IKillIcon
 		var attacker = EffectiveAttacker;
 
 		var damagable = attack.Target.GetComponentInParent<IDamageable>();
-		var rb = attack.Target.GetComponentInChildren<Rigidbody>();
 		var dir = Vector3.Direction( attack.Origin, attack.Position );
-
-		// Previous bullet force stuff, so the calculated force is the same as before. 
-		const float BulletVelocity = 100f;
-		var bulletForce = rb.IsValid() ? dir * rb.Mass * BulletVelocity : Vector3.Zero;
 
 		if ( damagable is not null )
 		{
@@ -337,16 +332,19 @@ public partial class BaseCarryable : Component, IKillIcon
 			info.Position = attack.Position;
 			info.Origin = attack.Origin;
 			info.Tags = attack.Tags;
-			if ( bulletForce != Vector3.Zero )
-				info.Force = dir * BulletVelocity;
+			info.Force = dir * 100f;
 
 			damagable.OnDamage( info );
+
+			// Prop.OnDamage consumes Force itself via ApplyImpulseAt, so skip the raw push
+			// below to avoid double-applying the impulse.
+			if ( damagable is Prop )
+				return;
 		}
 
-		if ( rb.IsValid() )
+		if ( attack.Target.GetComponentInChildren<Rigidbody>() is var rb && rb.IsValid() )
 		{
-			// TODO: Scale this based on damage?
-			rb.ApplyImpulseAt( attack.Position, bulletForce );
+			rb.ApplyImpulseAt( attack.Position, dir * rb.Mass * 100f );
 		}
 	}
 

--- a/Code/Game/Weapon/BaseCarryable/BaseCarryable.cs
+++ b/Code/Game/Weapon/BaseCarryable/BaseCarryable.cs
@@ -324,20 +324,29 @@ public partial class BaseCarryable : Component, IKillIcon
 		var attacker = EffectiveAttacker;
 
 		var damagable = attack.Target.GetComponentInParent<IDamageable>();
+		var rb = attack.Target.GetComponentInChildren<Rigidbody>();
+		var dir = Vector3.Direction( attack.Origin, attack.Position );
+
+		// Previous bullet force stuff, so the calculated force is the same as before. 
+		const float BulletVelocity = 100f;
+		var bulletForce = rb.IsValid() ? dir * rb.Mass * BulletVelocity : Vector3.Zero;
+
 		if ( damagable is not null )
 		{
 			var info = new DamageInfo( attack.Damage, attacker, GameObject, attack.Hitbox );
 			info.Position = attack.Position;
 			info.Origin = attack.Origin;
 			info.Tags = attack.Tags;
+			if ( bulletForce != Vector3.Zero )
+				info.Force = dir * BulletVelocity;
 
 			damagable.OnDamage( info );
 		}
 
-		if ( attack.Target.GetComponentInChildren<Rigidbody>() is var rb && rb.IsValid() )
+		if ( rb.IsValid() )
 		{
 			// TODO: Scale this based on damage?
-			rb.ApplyImpulseAt( attack.Position, Vector3.Direction( attack.Origin, attack.Position ) * rb.Mass * 100 );
+			rb.ApplyImpulseAt( attack.Position, bulletForce );
 		}
 	}
 

--- a/Code/GameLoop/GameManager.cs
+++ b/Code/GameLoop/GameManager.cs
@@ -323,6 +323,8 @@ public sealed partial class GameManager : GameObjectSystem<GameManager>, Compone
 
 		var dmg = new DamageInfo( 999999, null, null );
 		dmg.Tags.Add( DamageTags.GibAlways );
+		dmg.Origin = prop.WorldPosition;
+		dmg.Force = Vector3.Up * 100f;
 		damageable.OnDamage( in dmg );
 	}
 


### PR DESCRIPTION
## What

Goes with facepunch/sbox-public#11053.

Sets `DamageInfo.Force` in `BaseCarryable.TraceAttack` so bullet hits carry the push through the damage system properly. The engine side (`Prop.OnDamage`) reads it and applies the impulse to the prop's own body, so `rb.Velocity` is correct when `CreateGibs` reads it to scatter gibs.

Also skips the raw `rb.ApplyImpulseAt` for Prop targets since `Prop.OnDamage` handles the push now, otherwise it'd apply twice.