### PR TITLE
Add mass-unfreeze for physgun

### DIFF
--- a/Code/Components/FrozenBy.cs
+++ b/Code/Components/FrozenBy.cs
@@ -1,0 +1,27 @@
+/// <summary>
+/// Tracks which connection last froze this object with the physgun.
+/// Added when frozen, removed when unfrozen.
+/// </summary>
+public sealed class FrozenBy : Component
+{
+	[Sync( SyncFlags.FromHost )]
+	public Guid FreezerId { get; set; }
+
+	/// <summary>
+	/// Marks a gameObject as frozen by a connection, adding the component if it doesn't have one yet.
+	/// </summary>
+	public static void Set( GameObject go, Guid freezerId )
+	{
+		var frozen = go.GetOrAddComponent<FrozenBy>();
+		frozen.FreezerId = freezerId;
+	}
+
+	/// <summary>
+	/// Clears the frozen marker from a gameObject if it has one.
+	/// </summary>
+	public static void Clear( GameObject go )
+	{
+		if ( go.Components.TryGet<FrozenBy>( out var frozen ) )
+			frozen.Destroy();
+	}
+}

--- a/Code/Weapons/PhysGun/Physgun.cs
+++ b/Code/Weapons/PhysGun/Physgun.cs
@@ -73,6 +73,8 @@ public partial class Physgun
 
 	bool _launched;
 
+	TimeSince _lastReloadPress = 1000;
+
 	/// <summary>
 	/// The force applied to pull objects to us.
 	/// </summary>
@@ -87,6 +89,11 @@ public partial class Physgun
 	/// The distance at which we'll grab an object when pulling it towards us.
 	/// </summary>
 	static float PullDistance => 200.0f;
+
+	/// <summary>
+	/// Max time between reload presses to count as a double-tap.
+	/// </summary>
+	static float DoubleTapWindow => 0.4f;
 
 	public override void OnCameraMove( Player player, ref Angles angles )
 	{
@@ -181,7 +188,7 @@ public partial class Physgun
 
 				if ( Input.Down( "attack2" ) )
 				{
-					Freeze( _state.Body );
+					Freeze( _state.Body, player.Network.Owner.Id );
 					_state = default;
 					_preventReselect = true;
 					ViewModel?.PlaySound( ReleasedSound );
@@ -295,10 +302,16 @@ public partial class Physgun
 		}
 		else if ( Input.Pressed( "reload" ) )
 		{
-			if ( _stateHovered.IsValid() )
+			if ( _lastReloadPress < DoubleTapWindow )
+			{
+				UnfreezeAllFrozen( player.Network.Owner.Id );
+			}
+			else if ( _stateHovered.IsValid() )
 			{
 				UnfreezeAll( _stateHovered.Body );
 			}
+
+			_lastReloadPress = 0;
 		}
 		else
 		{
@@ -588,7 +601,7 @@ public partial class Physgun
 	}
 
 	[Rpc.Broadcast]
-	void Freeze( Rigidbody body )
+	void Freeze( Rigidbody body, Guid freezerId )
 	{
 		if ( !body.IsValid() ) return;
 
@@ -604,6 +617,7 @@ public partial class Physgun
 		if ( Networking.IsHost )
 		{
 			body.MotionEnabled = false;
+			FrozenBy.Set( body.GameObject, freezerId );
 		}
 	}
 
@@ -614,6 +628,7 @@ public partial class Physgun
 		if ( body.IsProxy ) return;
 
 		body.MotionEnabled = true;
+		FrozenBy.Clear( body.GameObject );
 	}
 
 	[Rpc.Broadcast]
@@ -635,6 +650,33 @@ public partial class Physgun
 		foreach ( var rb in bodies )
 		{
 			Unfreeze( rb );
+		}
+	}
+
+	[Rpc.Broadcast]
+	void UnfreezeAllFrozen( Guid freezerId )
+	{
+		if ( freezerId == Guid.Empty ) return;
+
+		foreach ( var rb in GetFrozenBodies( freezerId ) )
+		{
+			var effect = UnFreezeEffectPrefab.Clone( rb.WorldTransform );
+			foreach ( var emitter in effect.GetComponentsInChildren<ParticleModelEmitter>() )
+			{
+				emitter.Target = rb.GameObject;
+			}
+
+			Unfreeze( rb );
+		}
+	}
+
+	static IEnumerable<Rigidbody> GetFrozenBodies( Guid freezerId )
+	{
+		foreach ( var frozen in Game.ActiveScene.GetAllComponents<FrozenBy>() )
+		{
+			if ( frozen.FreezerId != freezerId ) continue;
+			if ( frozen.Components.TryGet<Rigidbody>( out var rb ) )
+				yield return rb;
 		}
 	}
 


### PR DESCRIPTION
Add FrozenBy.cs component tracking, which player froze an object
Physgun freeze now tags frozen body w/ freezer's connection ID
Double-tap reload (within 0.4s) unfreezes all objects frozen by that player, not just the hovered or owned ones.